### PR TITLE
Add missing include

### DIFF
--- a/qmetaobject/src/qtdeclarative.rs
+++ b/qmetaobject/src/qtdeclarative.rs
@@ -18,6 +18,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 use super::*;
 
 cpp!{{
+    #include <memory>
     #include <QtQuick/QtQuick>
     #include <QtCore/QDebug>
 


### PR DESCRIPTION
#include &lt;memory&gt; is needed at least in Qt 5.9.