### PR TITLE
Read-only QAbstractItemModel support

### DIFF
--- a/qmetaobject/src/itemmodel.rs
+++ b/qmetaobject/src/itemmodel.rs
@@ -1,0 +1,151 @@
+/* Copyright (C) 2018 Olivier Goffart <ogoffart@woboq.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+use super::*;
+use std::collections::HashMap;
+
+/// This trait allow to override a Qt QAbstractItemModel
+pub trait QAbstractItemModel: QObject {
+    /// Required for the implementation detail of the QObject custom derive
+    fn get_object_description() -> &'static QObjectDescription
+    where
+        Self: Sized,
+    {
+        unsafe {
+            cpp!([]-> &'static QObjectDescription as "RustObjectDescription const*" {
+            return rustObjectDescription<Rust_QAbstractItemModel>();
+        } )
+        }
+    }
+    /// Required for the implementation detail of the QObject custom derive
+    unsafe fn get_rust_object<'a>(p: &'a mut c_void) -> &'a mut Self
+    where
+        Self: Sized,
+    {
+        let ptr = cpp!{[p as "RustObject<QAbstractItemModel>*"] -> *mut c_void as "void*" {
+            return p->rust_object.a;
+        }};
+        std::mem::transmute::<*mut c_void, &'a mut Self>(ptr)
+    }
+
+    /// Refer to the Qt documentation of QAbstractItemModel::index
+    fn index(&self, row: i32, column: i32, parent: QModelIndex) -> QModelIndex;
+    /// Refer to the Qt documentation of QAbstractItemModel::parent
+    fn parent(&self, index: QModelIndex) -> QModelIndex;
+    /// Refer to the Qt documentation of QAbstractItemModel::rowCount
+    fn row_count(&self, parent: QModelIndex) -> i32;
+    /// Refer to the Qt documentation of QAbstractItemModel::columnCount
+    fn column_count(&self, parent: QModelIndex) -> i32;
+    /// Refer to the Qt documentation of QAbstractItemModel::data
+    fn data(&self, index: QModelIndex, role: i32) -> QVariant;
+    /// Refer to the Qt documentation of QAbstractItemModel::setData
+    fn set_data(&mut self, _index: QModelIndex, _value: &QVariant, _role: i32) -> bool {
+        false
+    }
+    /// Refer to the Qt documentation of QAbstractItemModel::roleNames
+    fn role_names(&self) -> HashMap<i32, QByteArray> {
+        HashMap::new()
+    }
+}
+
+impl QAbstractItemModel {
+    /// Refer to the Qt documentation of QAbstractItemModel::createIndex
+    pub fn create_index(&self, row: i32, column: i32, id: usize) -> QModelIndex {
+        let obj = self.get_cpp_object();
+        unsafe {
+            cpp!([obj as "Rust_QAbstractItemModel*", row as "int", column as "int", id as "uintptr_t"] -> QModelIndex as "QModelIndex" {
+            return obj ? obj->createIndex(row, column, id) : QModelIndex();
+        })
+        }
+    }
+}
+
+cpp!{{
+#include <qmetaobject_rust.hpp>
+#include <QtCore/QAbstractItemModel>
+}}
+
+cpp!{{
+struct Rust_QAbstractItemModel : RustObject<QAbstractItemModel> {
+
+    using QAbstractItemModel::createIndex;
+
+    const QMetaObject *metaObject() const override {
+        return rust!(Rust_QAbstractItemModel_metaobject[rust_object : &QAbstractItemModel as "TraitObject"]
+                -> *const QMetaObject as "const QMetaObject*" {
+            rust_object.meta_object()
+        });
+    }
+
+    QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override {
+        return rust!(Rust_QAbstractItemModel_index[rust_object : &QAbstractItemModel as "TraitObject",
+                row : i32 as "int", column : i32 as "int", parent : QModelIndex as "QModelIndex"] -> QModelIndex as "QModelIndex" {
+            rust_object.index(row, column, parent)
+        });
+    }
+
+    QModelIndex parent(const QModelIndex &index) const override {
+        return rust!(Rust_QAbstractItemModel_parent[rust_object : &QAbstractItemModel as "TraitObject",
+                index : QModelIndex as "QModelIndex"] -> QModelIndex as "QModelIndex" {
+            rust_object.parent(index)
+        });
+    }
+
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override {
+        return rust!(Rust_QAbstractItemModel_rowCount[rust_object : &QAbstractItemModel as "TraitObject",
+                  parent : QModelIndex as "QModelIndex"]
+                -> i32 as "int" {
+            rust_object.row_count(parent)
+        });
+    }
+
+    int columnCount(const QModelIndex &parent = QModelIndex()) const override {
+        return rust!(Rust_QAbstractItemModel_columnCount[rust_object : &QAbstractItemModel as "TraitObject",
+                     parent : QModelIndex as "QModelIndex"]
+                -> i32 as "int" {
+            rust_object.column_count(parent)
+        });
+    }
+
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override {
+        return rust!(Rust_QAbstractItemModel_data[rust_object : &QAbstractItemModel as "TraitObject",
+                index : QModelIndex as "QModelIndex", role : i32 as "int"] -> QVariant as "QVariant" {
+            rust_object.data(index, role)
+        });
+    }
+
+    bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override {
+        return rust!(Rust_QAbstractItemModel_setData[rust_object : &mut QAbstractItemModel as "TraitObject",
+                index : QModelIndex as "QModelIndex", value : QVariant as "QVariant", role : i32 as "int"]
+                -> bool as "bool" {
+            rust_object.set_data(index, &value, role)
+        });
+    }
+
+    QHash<int, QByteArray> roleNames() const override {
+        QHash<int, QByteArray> base = QAbstractItemModel::roleNames();
+        rust!(Rust_QAbstractItemModel_roleNames[rust_object : &QAbstractItemModel as "TraitObject",
+                base: *mut c_void as "QHash<int, QByteArray>&"] {
+            for (key, val) in rust_object.role_names().iter() {
+                add_to_hash(base, key.clone(), val.clone());
+            }
+        });
+        return base;
+    }
+};
+}}

--- a/qmetaobject/src/lib.rs
+++ b/qmetaobject/src/lib.rs
@@ -379,6 +379,8 @@ fn add_to_hash(hash: *mut c_void, key: i32, value: QByteArray) {
 /// Refer to the documentation of Qt::UserRole
 pub const USER_ROLE: i32 = 0x0100;
 
+pub mod itemmodel;
+pub use itemmodel::*;
 pub mod listmodel;
 pub use listmodel::*;
 pub mod qtdeclarative;

--- a/qmetaobject/src/lib.rs
+++ b/qmetaobject/src/lib.rs
@@ -367,6 +367,17 @@ pub fn single_shot<F>(interval : std::time::Duration, func : F) where F: FnMut()
     })};
 }
 
+/* Small helper function for Rust_QAbstractItemModel::roleNames */
+fn add_to_hash(hash: *mut c_void, key: i32, value: QByteArray) {
+    unsafe {
+        cpp!([hash as "QHash<int, QByteArray>*", key as "int", value as "QByteArray"]{
+        (*hash)[key] = std::move(value);
+    })
+    }
+}
+
+/// Refer to the documentation of Qt::UserRole
+pub const USER_ROLE: i32 = 0x0100;
 
 pub mod listmodel;
 pub use listmodel::*;

--- a/qmetaobject/src/listmodel.rs
+++ b/qmetaobject/src/listmodel.rs
@@ -111,13 +111,6 @@ impl QAbstractListModel {
     }
 }
 
-/* Small helper function for Rust_QAbstractListModel::roleNames */
-fn add_to_hash(hash: *mut c_void, key: i32, value: QByteArray) {
-    unsafe { cpp!([hash as "QHash<int, QByteArray>*", key as "int", value as "QByteArray"]{
-        (*hash)[key] = std::move(value);
-    })}
-}
-
 cpp!{{
 #include <qmetaobject_rust.hpp>
 #include <QtCore/QAbstractListModel>
@@ -182,9 +175,6 @@ struct Rust_QAbstractListModel : RustObject<QAbstractListModel> {
     //QModelIndex parent(const QModelIndex &child) const override;
 };
 }}
-
-/// Refer to the documentation of Qt::UserRole
-pub const USER_ROLE : i32 = 0x0100;
 
 /// A trait used in SimpleListModel.
 pub trait SimpleListItem {

--- a/qmetaobject/src/listmodel.rs
+++ b/qmetaobject/src/listmodel.rs
@@ -114,6 +114,9 @@ impl QAbstractListModel {
 cpp!{{
 #include <qmetaobject_rust.hpp>
 #include <QtCore/QAbstractListModel>
+}}
+
+cpp!{{
 struct Rust_QAbstractListModel : RustObject<QAbstractListModel> {
 
     using QAbstractListModel::beginInsertRows;

--- a/qmetaobject/src/qttypes.rs
+++ b/qmetaobject/src/qttypes.rs
@@ -283,44 +283,44 @@ mod tests {
 
     #[test]
     fn test_qvariantlist_from_iter() {
-        let v = vec![1u32,2u32,3u32];
-        let qvl : QVariantList = v.iter().collect();
+        let v = vec![1u32, 2u32, 3u32];
+        let qvl: QVariantList = v.iter().collect();
         assert_eq!(qvl.len(), 3);
         assert_eq!(qvl[1].to_qbytearray().to_string(), "2");
-
     }
 
     #[test]
     fn test_qstring_and_qbytearrazy() {
-        let qba1 : QByteArray = (b"hello" as &[u8]).into();
-        let qba2 : QByteArray = "hello".into();
-        let s : String = "hello".into();
-        let qba3 : QByteArray = s.clone().into();
+        let qba1: QByteArray = (b"hello" as &[u8]).into();
+        let qba2: QByteArray = "hello".into();
+        let s: String = "hello".into();
+        let qba3: QByteArray = s.clone().into();
 
         assert_eq!(qba1.to_string(), "hello");
         assert_eq!(qba2.to_string(), "hello");
         assert_eq!(qba3.to_string(), "hello");
 
-        let qs1 : QString = "hello".into();
-        let qs2 : QString = s.into();
-        let qba4 : QByteArray = qs1.clone().into();
+        let qs1: QString = "hello".into();
+        let qs2: QString = s.into();
+        let qba4: QByteArray = qs1.clone().into();
 
         assert_eq!(qs1.to_string(), "hello");
         assert_eq!(qs2.to_string(), "hello");
         assert_eq!(qba4.to_string(), "hello");
-
     }
 }
-
 
 cpp_class!(pub unsafe struct QModelIndex as "QModelIndex");
 impl QModelIndex {
-    pub fn row(&self) -> i32 {
+    pub fn id(&self) -> usize {
         unsafe {
-            cpp!([self as "const QModelIndex*"] -> i32 as "int" { return self->row(); })
+            cpp!([self as "const QModelIndex*"] -> usize as "uintptr_t" { return self->internalId(); })
         }
     }
+    pub fn column(&self) -> i32 {
+        unsafe { cpp!([self as "const QModelIndex*"] -> i32 as "int" { return self->column(); }) }
+    }
+    pub fn row(&self) -> i32 {
+        unsafe { cpp!([self as "const QModelIndex*"] -> i32 as "int" { return self->row(); }) }
+    }
 }
-
-
-


### PR DESCRIPTION
As discussed in #4 

This is a very early work-in-progress to add the ability to specify QAbstractItemModel as a base class.  The generated code fails to compile.

The approach thus far has been to copy the listmodel code and make adjustments.  The idea is to get a read-only model working and then add additional methods.