### PR TITLE
Specify -qt5 in qmake command

### DIFF
--- a/examples/graph/build.rs
+++ b/examples/graph/build.rs
@@ -21,7 +21,7 @@ use std::process::Command;
 fn qmake_query(var: &str) -> String {
     String::from_utf8(
         Command::new("qmake")
-            .args(&["-query", var])
+            .args(&["-qt5", "-query", var])
             .output()
             .expect("Failed to execute qmake. Make sure 'qmake' is in your path")
             .stdout,

--- a/qmetaobject/build.rs
+++ b/qmetaobject/build.rs
@@ -21,7 +21,7 @@ use std::process::Command;
 fn qmake_query(var: &str) -> String {
     String::from_utf8(
         Command::new("qmake")
-            .args(&["-query", var])
+            .args(&["-qt5", "-query", var])
             .output()
             .expect("Failed to execute qmake. Make sure 'qmake' is in your path")
             .stdout,


### PR DESCRIPTION
Generally, the default version of Qt used by qtchooser (and therefore qmake) is Qt4