### PR TITLE
Add ability to initialize the QtWebEngine, gated behind a feature

### DIFF
--- a/qmetaobject/Cargo.toml
+++ b/qmetaobject/Cargo.toml
@@ -9,6 +9,10 @@ license = "MIT"
 keywords = ["Qt", "QML", "QMetaObject",]
 repository = "https://github.com/woboq/qmetaobject-rs"
 
+[features]
+default = []
+webengine = []
+
 [dependencies]
 qmetaobject_impl = { path = "../qmetaobject_impl", version = "=0.0.3"}
 lazy_static = "1.0"

--- a/qmetaobject/build.rs
+++ b/qmetaobject/build.rs
@@ -53,4 +53,6 @@ fn main() {
     println!("cargo:rustc-link-lib{}=Qt{}Core", macos_lib_search, macos_lib_framework);
     println!("cargo:rustc-link-lib{}=Qt{}Quick", macos_lib_search, macos_lib_framework);
     println!("cargo:rustc-link-lib{}=Qt{}Qml", macos_lib_search, macos_lib_framework);
+    #[cfg(feature = "webengine")]
+    println!("cargo:rustc-link-lib{}=Qt{}WebEngine", macos_lib_search, macos_lib_framework);
 }

--- a/qmetaobject/src/qtdeclarative.rs
+++ b/qmetaobject/src/qtdeclarative.rs
@@ -37,6 +37,23 @@ cpp!{{
     };
 }}
 
+#[cfg(feature = "webengine")]
+cpp!{{
+    #include <QtWebEngine/QtWebEngine>
+}}
+
+
+#[cfg(feature = "webengine")]
+pub struct QtWebEngine;
+#[cfg(feature = "webengine")]
+impl QtWebEngine {
+    pub fn initialize() {
+        cpp!(unsafe [] {
+            QtWebEngine::initialize();
+        });
+    }
+}
+
 /// Wrap a Qt Application and a QmlEngine
 cpp_class!(pub unsafe struct QmlEngine as "QmlEngineHolder");
 impl QmlEngine {


### PR DESCRIPTION
This adds a new `webengine` feature to the crate which, when enabled,
adds the ability to initialize the `QtWebEngine` and links against the
corresponding libraries.