### PR TITLE
Add #[derive(QEnum)]

### DIFF
--- a/qmetaobject/src/lib.rs
+++ b/qmetaobject/src/lib.rs
@@ -409,6 +409,16 @@ pub trait QGadget {
         Self: Sized;
 }
 
+/// Trait that is implemented by the QEnum custom derive macro
+///
+/// Do not implement this trait yourself, use `#[derive(QEnum)]`.
+pub trait QEnum {
+    /// Returns a pointer to a meta object
+    fn static_meta_object() -> *const QMetaObject
+    where
+        Self: Sized;
+}
+
 #[doc(hidden)]
 #[no_mangle]
 pub unsafe extern "C" fn RustObject_metaObject(p: *mut RefCell<QObject>) -> *const QMetaObject {
@@ -445,7 +455,8 @@ pub struct QMetaObject {
     pub superdata: *const QMetaObject,
     pub string_data: *const u8,
     pub data: *const u32,
-    pub static_metacall: extern "C" fn(o: *mut c_void, c: u32, idx: u32, a: *const *mut c_void),
+    pub static_metacall:
+        Option<extern "C" fn(o: *mut c_void, c: u32, idx: u32, a: *const *mut c_void)>,
     pub r: *const c_void,
     pub e: *const c_void,
 }

--- a/qmetaobject/src/qtdeclarative.rs
+++ b/qmetaobject/src/qtdeclarative.rs
@@ -239,6 +239,27 @@ pub fn qml_register_type<T: QObject + Default + Sized>(
     })}
 }
 
+/// Register the given enum as a QML type
+///
+/// Refer to the Qt documentation for qmlRegisterUncreatableMetaObject.
+pub fn qml_register_enum<T: QEnum>(
+    uri: &std::ffi::CStr,
+    version_major: u32,
+    version_minor: u32,
+    qml_name: &std::ffi::CStr,
+)
+{
+    let uri_ptr = uri.as_ptr();
+    let qml_name_ptr = qml_name.as_ptr();
+    let meta_object = T::static_meta_object();
+
+    unsafe { cpp!([qml_name_ptr as "char*", uri_ptr as "char*", version_major as "int",
+                    version_minor as "int", meta_object as "const QMetaObject *"]{
+        qmlRegisterUncreatableMetaObject(*meta_object, uri_ptr, version_major,
+            version_minor, qml_name_ptr, "Access to enums & flags only");
+    })}
+}
+
 /// A QObject-like trait to inherit from QQuickItem.
 ///
 /// Work in progress

--- a/qmetaobject/tests/tests.rs
+++ b/qmetaobject/tests/tests.rs
@@ -606,3 +606,44 @@ fn panic_when_moved_setter() {
     do_test(my_obj, "Item { function doTest() { _obj.prop_y = 45; } }");
 }
 */
+
+#[derive(QEnum)]
+#[repr(u8)]
+enum MyEnum {
+    None,
+    First = 1,
+    Four = 4,
+}
+
+#[derive(QObject, Default)]
+struct MyEnumObject {
+    base: qt_base_class!(trait QObject),
+}
+
+#[test]
+fn enum_properties() {
+    qml_register_enum::<MyEnum>(
+        CStr::from_bytes_with_nul(b"MyEnumLib\0").unwrap(),
+        1,
+        0,
+        CStr::from_bytes_with_nul(b"MyEnum\0").unwrap(),
+    );
+    let my_obj = MyObject::default();
+    assert!(do_test(
+        my_obj,
+        "import MyEnumLib 1.0
+        Item {
+        function doTest() {
+            if(MyEnum.None != 0) {
+                return false;
+            }
+            if(MyEnum.First != 1) {
+                return false;
+            }
+            if(MyEnum.Four != 4) {
+                return false;
+            }
+            return true;
+        }}"
+    ));
+}

--- a/qmetaobject_impl/src/lib.rs
+++ b/qmetaobject_impl/src/lib.rs
@@ -70,6 +70,12 @@ pub fn qgadget_impl(input: TokenStream) -> TokenStream {
     qobject_impl::generate(input, false)
 }
 
+/// Implementation of #[derive(QEnum)]
+#[proc_macro_derive(QEnum, attributes(QMetaObjectCrate))]
+pub fn qenum_impl(input: TokenStream) -> TokenStream {
+    qobject_impl::generate_enum(input)
+}
+
 /// Implementation of the qmetaobject::qrc! macro
 #[proc_macro]
 pub fn qrc_internal(input: TokenStream) -> TokenStream {


### PR DESCRIPTION
Only add the meta-object, not the property support:
- We can register a enum in the QML engine and use it from QML side
- We can not yet use it as a object property

Enum values are stored in an array of `u32`, so 32 is the maximal size that will correctly work (moc doesn't check...). So I choice to force the use of the attribute `#[repr(*)]` limited to `u8, u16, u32, i8, i16, i32`.

I needed to change `QMetaObject.static_metacall` to an option type as an `extern "C" fn` pointer can not be set to null (see https://github.com/rust-lang/rust/issues/8730). The namespace meta-object doesn't have an associated `static_metacall` function so we need to be able to set it to null.

I work with Qt 5.12.1 so my moc output example is in version 8. I had to bump the version from 7 to 8 to make it work. I don't know if it possible to make it work in version 7.

I'm still working on the property part.
