### PR TITLE
Fix `dyn Trait` warnings for rust 1.37

### DIFF
--- a/examples/todos/src/implementation.rs
+++ b/examples/todos/src/implementation.rs
@@ -64,8 +64,8 @@ impl Todos {
             return false;
         }
         self.list[item].completed = v;
-        let idx = (self as &mut QAbstractListModel).row_index(item as i32);
-        (self as &mut QAbstractListModel).data_changed(idx.clone(), idx);
+        let idx = (self as &mut dyn QAbstractListModel).row_index(item as i32);
+        (self as &mut dyn QAbstractListModel).data_changed(idx.clone(), idx);
         self.update_active_count();
         true
     }
@@ -76,8 +76,8 @@ impl Todos {
             return false;
         }
         self.list[item].description = v;
-        let idx = (self as &mut QAbstractListModel).row_index(item as i32);
-        (self as &mut QAbstractListModel).data_changed(idx.clone(), idx);
+        let idx = (self as &mut dyn QAbstractListModel).row_index(item as i32);
+        (self as &mut dyn QAbstractListModel).data_changed(idx.clone(), idx);
         true
     }
 
@@ -85,11 +85,11 @@ impl Todos {
         if count == 0 || row > self.list.len() {
             return false;
         }
-        (self as &mut QAbstractListModel).begin_insert_rows(row as i32, (row + count - 1) as i32);
+        (self as &mut dyn QAbstractListModel).begin_insert_rows(row as i32, (row + count - 1) as i32);
         for i in 0..count {
             self.list.insert(row + i, TodosItem::default());
         }
-        (self as &mut QAbstractListModel).end_insert_rows();
+        (self as &mut dyn QAbstractListModel).end_insert_rows();
         self.activeCount += count;
         self.active_count_changed();
         self.count_changed();
@@ -100,9 +100,9 @@ impl Todos {
         if count == 0 || row + count > self.list.len() {
             return false;
         }
-        (self as &mut QAbstractListModel).begin_remove_rows(row as i32, (row + count - 1) as i32);
+        (self as &mut dyn QAbstractListModel).begin_remove_rows(row as i32, (row + count - 1) as i32);
         self.list.drain(row..row + count);
-        (self as &mut QAbstractListModel).end_remove_rows();
+        (self as &mut dyn QAbstractListModel).end_remove_rows();
         self.count_changed();
         self.update_active_count();
         true
@@ -110,17 +110,17 @@ impl Todos {
 
     #[allow(non_snake_case)]
     fn clearCompleted(&mut self) {
-        (self as &mut QAbstractListModel).begin_reset_model();
+        (self as &mut dyn QAbstractListModel).begin_reset_model();
         self.list.retain(|i| !i.completed);
-        (self as &mut QAbstractListModel).end_reset_model();
+        (self as &mut dyn QAbstractListModel).end_reset_model();
         self.count_changed();
     }
 
     fn add(&mut self, description: String) {
         let end = self.list.len();
-        (self as &mut QAbstractListModel).begin_insert_rows(end as i32, end as i32);
+        (self as &mut dyn QAbstractListModel).begin_insert_rows(end as i32, end as i32);
         self.list.insert(end, TodosItem { completed: false, description });
-        (self as &mut QAbstractListModel).end_insert_rows();
+        (self as &mut dyn QAbstractListModel).end_insert_rows();
         self.activeCount += 1;
         self.active_count_changed();
         self.count_changed();
@@ -136,10 +136,10 @@ impl Todos {
             i.completed = completed;
         }
 
-        let idx1 = (self as &mut QAbstractListModel).row_index(0);
+        let idx1 = (self as &mut dyn QAbstractListModel).row_index(0);
         let end = self.list.len() as i32;
-        let idx2 = (self as &mut QAbstractListModel).row_index(end - 1);
-        (self as &mut QAbstractListModel).data_changed(idx1, idx2);
+        let idx2 = (self as &mut dyn QAbstractListModel).row_index(end - 1);
+        (self as &mut dyn QAbstractListModel).data_changed(idx1, idx2);
         self.update_active_count();
     }
 }

--- a/qmetaobject/src/connections.rs
+++ b/qmetaobject/src/connections.rs
@@ -45,7 +45,7 @@ class RustSlotOject : public QtPrivate::QSlotObjectBase
             break;
         case Call: {
             auto slot = static_cast<RustSlotOject*>(this_)->slot;
-            rust!(RustSlotObject_call[slot : *mut FnMut(*const *const c_void) as "TraitObject", a : *const *const c_void as "void**"] {
+            rust!(RustSlotObject_call[slot : *mut dyn FnMut(*const *const c_void) as "TraitObject", a : *const *const c_void as "void**"] {
                    unsafe { (*slot)(a); }
                 });
             break;
@@ -57,7 +57,7 @@ class RustSlotOject : public QtPrivate::QSlotObjectBase
     }
 public:
     explicit RustSlotOject(TraitObject slot) : QSlotObjectBase(&impl), slot(slot) {}
-    ~RustSlotOject() { rust!(RustSlotOject_destruct [slot : *mut FnMut(*const *const c_void) as "TraitObject"] { unsafe { let _ = Box::from_raw(slot); } }); }
+    ~RustSlotOject() { rust!(RustSlotOject_destruct [slot : *mut dyn FnMut(*const *const c_void) as "TraitObject"] { unsafe { let _ = Box::from_raw(slot); } }); }
     Q_DISABLE_COPY(RustSlotOject);
 };
 
@@ -202,7 +202,7 @@ pub unsafe fn connect<Args, F: Slot<Args>>(
 ) -> ConnectionHandle {
     let mut cpp_signal = signal.inner;
     let apply_closure = move |a: *const *const c_void| slot.apply(a);
-    let b: Box<FnMut(*const *const c_void)> = Box::new(apply_closure);
+    let b: Box<dyn FnMut(*const *const c_void)> = Box::new(apply_closure);
     let slot_raw = Box::into_raw(b);
     /*unsafe*/
     {

--- a/qmetaobject/src/itemmodel.rs
+++ b/qmetaobject/src/itemmodel.rs
@@ -53,7 +53,7 @@ pub trait QAbstractItemModel: QObject {
     }
 }
 
-impl QAbstractItemModel {
+impl dyn QAbstractItemModel {
     /// Refer to the Qt documentation of QAbstractListModel::beginInsertRows
     pub fn begin_insert_rows(&self, parent: QModelIndex, first: i32, last: i32) {
         let obj = self.get_cpp_object();
@@ -114,14 +114,14 @@ impl QAbstractItemModel {
     where
         F: FnMut(QModelIndex) -> QModelIndex,
     {
-        let f: &mut FnMut(QModelIndex) -> QModelIndex = &mut f;
+        let f: &mut dyn FnMut(QModelIndex) -> QModelIndex = &mut f;
         let obj = self.get_cpp_object();
         cpp!(unsafe [obj as "Rust_QAbstractItemModel*", f as "TraitObject"] {
             if (!obj) return;
             const auto list1 = obj->persistentIndexList();
             auto list2 = list1;
             for (QModelIndex &idx : list2) {
-                rust!(update_model_indexes [f : &mut FnMut(QModelIndex)->QModelIndex as "TraitObject", idx : &mut QModelIndex as "QModelIndex&"] {
+                rust!(update_model_indexes [f : &mut dyn FnMut(QModelIndex)->QModelIndex as "TraitObject", idx : &mut QModelIndex as "QModelIndex&"] {
                     *idx = f(*idx);
                 });
             }
@@ -175,21 +175,21 @@ struct Rust_QAbstractItemModel : RustObject<QAbstractItemModel> {
     using QAbstractItemModel::persistentIndexList;
 
     QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override {
-        return rust!(Rust_QAbstractItemModel_index[rust_object : QObjectPinned<QAbstractItemModel> as "TraitObject",
+        return rust!(Rust_QAbstractItemModel_index[rust_object : QObjectPinned<dyn QAbstractItemModel> as "TraitObject",
                 row : i32 as "int", column : i32 as "int", parent : QModelIndex as "QModelIndex"] -> QModelIndex as "QModelIndex" {
             rust_object.borrow().index(row, column, parent)
         });
     }
 
     QModelIndex parent(const QModelIndex &index) const override {
-        return rust!(Rust_QAbstractItemModel_parent[rust_object : QObjectPinned<QAbstractItemModel> as "TraitObject",
+        return rust!(Rust_QAbstractItemModel_parent[rust_object : QObjectPinned<dyn QAbstractItemModel> as "TraitObject",
                 index : QModelIndex as "QModelIndex"] -> QModelIndex as "QModelIndex" {
             rust_object.borrow().parent(index)
         });
     }
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const override {
-        return rust!(Rust_QAbstractItemModel_rowCount[rust_object : QObjectPinned<QAbstractItemModel> as "TraitObject",
+        return rust!(Rust_QAbstractItemModel_rowCount[rust_object : QObjectPinned<dyn QAbstractItemModel> as "TraitObject",
                   parent : QModelIndex as "QModelIndex"]
                 -> i32 as "int" {
             rust_object.borrow().row_count(parent)
@@ -197,7 +197,7 @@ struct Rust_QAbstractItemModel : RustObject<QAbstractItemModel> {
     }
 
     int columnCount(const QModelIndex &parent = QModelIndex()) const override {
-        return rust!(Rust_QAbstractItemModel_columnCount[rust_object : QObjectPinned<QAbstractItemModel> as "TraitObject",
+        return rust!(Rust_QAbstractItemModel_columnCount[rust_object : QObjectPinned<dyn QAbstractItemModel> as "TraitObject",
                      parent : QModelIndex as "QModelIndex"]
                 -> i32 as "int" {
             rust_object.borrow().column_count(parent)
@@ -205,14 +205,14 @@ struct Rust_QAbstractItemModel : RustObject<QAbstractItemModel> {
     }
 
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override {
-        return rust!(Rust_QAbstractItemModel_data[rust_object : QObjectPinned<QAbstractItemModel> as "TraitObject",
+        return rust!(Rust_QAbstractItemModel_data[rust_object : QObjectPinned<dyn QAbstractItemModel> as "TraitObject",
                 index : QModelIndex as "QModelIndex", role : i32 as "int"] -> QVariant as "QVariant" {
             rust_object.borrow().data(index, role)
         });
     }
 
     bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override {
-        return rust!(Rust_QAbstractItemModel_setData[rust_object : QObjectPinned<QAbstractItemModel> as "TraitObject",
+        return rust!(Rust_QAbstractItemModel_setData[rust_object : QObjectPinned<dyn QAbstractItemModel> as "TraitObject",
                 index : QModelIndex as "QModelIndex", value : QVariant as "QVariant", role : i32 as "int"]
                 -> bool as "bool" {
             rust_object.borrow_mut().set_data(index, &value, role)
@@ -221,7 +221,7 @@ struct Rust_QAbstractItemModel : RustObject<QAbstractItemModel> {
 
     QHash<int, QByteArray> roleNames() const override {
         QHash<int, QByteArray> base = QAbstractItemModel::roleNames();
-        rust!(Rust_QAbstractItemModel_roleNames[rust_object : QObjectPinned<QAbstractItemModel> as "TraitObject",
+        rust!(Rust_QAbstractItemModel_roleNames[rust_object : QObjectPinned<dyn QAbstractItemModel> as "TraitObject",
                 base: *mut c_void as "QHash<int, QByteArray>&"] {
             for (key, val) in rust_object.borrow().role_names().iter() {
                 add_to_hash(base, *key, val.clone());

--- a/qmetaobject/src/listmodel.rs
+++ b/qmetaobject/src/listmodel.rs
@@ -50,7 +50,7 @@ pub trait QAbstractListModel: QObject {
 }
 
 // FIXME! code duplication with impl QAbstractItemModel
-impl QAbstractListModel {
+impl dyn QAbstractListModel {
     /// Refer to the Qt documentation of QAbstractListModel::beginInsertRows
     pub fn begin_insert_rows(&mut self, first: i32, last: i32) {
         let p = QModelIndex::default();
@@ -145,7 +145,7 @@ struct Rust_QAbstractListModel : RustObject<QAbstractListModel> {
     using QAbstractListModel::endResetModel;
 
     int rowCount(const QModelIndex & = QModelIndex()) const override {
-        return rust!(Rust_QAbstractListModel_rowCount[rust_object : QObjectPinned<QAbstractListModel> as "TraitObject"]
+        return rust!(Rust_QAbstractListModel_rowCount[rust_object : QObjectPinned<dyn QAbstractListModel> as "TraitObject"]
                 -> i32 as "int" {
             rust_object.borrow().row_count()
         });
@@ -154,14 +154,14 @@ struct Rust_QAbstractListModel : RustObject<QAbstractListModel> {
     //int columnCount(const QModelIndex &parent = QModelIndex()) const override;
 
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override {
-        return rust!(Rust_QAbstractListModel_data[rust_object : QObjectPinned<QAbstractListModel> as "TraitObject",
+        return rust!(Rust_QAbstractListModel_data[rust_object : QObjectPinned<dyn QAbstractListModel> as "TraitObject",
                 index : QModelIndex as "QModelIndex", role : i32 as "int"] -> QVariant as "QVariant" {
             rust_object.borrow().data(index, role)
         });
     }
 
     bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override {
-        return rust!(Rust_QAbstractListModel_setData[rust_object : QObjectPinned<QAbstractListModel> as "TraitObject",
+        return rust!(Rust_QAbstractListModel_setData[rust_object : QObjectPinned<dyn QAbstractListModel> as "TraitObject",
                 index : QModelIndex as "QModelIndex", value : QVariant as "QVariant", role : i32 as "int"]
                 -> bool as "bool" {
             rust_object.borrow_mut().set_data(index, &value, role)
@@ -174,7 +174,7 @@ struct Rust_QAbstractListModel : RustObject<QAbstractListModel> {
 
     QHash<int, QByteArray> roleNames() const override {
         QHash<int, QByteArray> base = QAbstractListModel::roleNames();
-        rust!(Rust_QAbstractListModel_roleNames[rust_object : QObjectPinned<QAbstractListModel> as "TraitObject",
+        rust!(Rust_QAbstractListModel_roleNames[rust_object : QObjectPinned<dyn QAbstractListModel> as "TraitObject",
                 base: *mut c_void as "QHash<int, QByteArray>&"] {
             for (key, val) in rust_object.borrow().role_names().iter() {
                 add_to_hash(base, *key, val.clone());
@@ -236,28 +236,28 @@ where
 }
 impl<T: SimpleListItem> SimpleListModel<T> {
     pub fn insert(&mut self, index: usize, element: T) {
-        (self as &mut QAbstractListModel).begin_insert_rows(index as i32, index as i32);
+        (self as &mut dyn QAbstractListModel).begin_insert_rows(index as i32, index as i32);
         self.values.insert(index, element);
-        (self as &mut QAbstractListModel).end_insert_rows();
+        (self as &mut dyn QAbstractListModel).end_insert_rows();
     }
     pub fn push(&mut self, value: T) {
         let idx = self.values.len();
         self.insert(idx, value);
     }
     pub fn remove(&mut self, index: usize) {
-        (self as &mut QAbstractListModel).begin_remove_rows(index as i32, index as i32);
+        (self as &mut dyn QAbstractListModel).begin_remove_rows(index as i32, index as i32);
         self.values.remove(index);
-        (self as &mut QAbstractListModel).end_remove_rows();
+        (self as &mut dyn QAbstractListModel).end_remove_rows();
     }
     pub fn change_line(&mut self, index: usize, value: T) {
         self.values[index] = value;
-        let idx = (self as &mut QAbstractListModel).row_index(index as i32);
-        (self as &mut QAbstractListModel).data_changed(idx, idx);
+        let idx = (self as &mut dyn QAbstractListModel).row_index(index as i32);
+        (self as &mut dyn QAbstractListModel).data_changed(idx, idx);
     }
     pub fn reset_data(&mut self, data: Vec<T>) {
-        (self as &mut QAbstractListModel).begin_reset_model();
+        (self as &mut dyn QAbstractListModel).begin_reset_model();
         self.values = data;
-        (self as &mut QAbstractListModel).end_reset_model();
+        (self as &mut dyn QAbstractListModel).end_reset_model();
     }
 }
 

--- a/qmetaobject/src/qtdeclarative.rs
+++ b/qmetaobject/src/qtdeclarative.rs
@@ -310,14 +310,14 @@ struct Rust_QQuickItem : RustObject<QQuickItem> {
     virtual void itemChange(ItemChange, const ItemChangeData &);*/
     void classBegin() override {
         QQuickItem::classBegin();
-        rust!(Rust_QQuickItem_classBegin[rust_object : QObjectPinned<QQuickItem> as "TraitObject"] {
+        rust!(Rust_QQuickItem_classBegin[rust_object : QObjectPinned<dyn QQuickItem> as "TraitObject"] {
             rust_object.borrow_mut().class_begin();
         });
     }
 
     void componentComplete() override {
         QQuickItem::componentComplete();
-        rust!(Rust_QQuickItem_componentComplete[rust_object : QObjectPinned<QQuickItem> as "TraitObject"] {
+        rust!(Rust_QQuickItem_componentComplete[rust_object : QObjectPinned<dyn QQuickItem> as "TraitObject"] {
             rust_object.borrow_mut().component_complete();
         });
     }
@@ -335,7 +335,7 @@ struct Rust_QQuickItem : RustObject<QQuickItem> {
 
     void handleMouseEvent(QMouseEvent *event) {
        if (!rust!(Rust_QQuickItem_mousePressEvent[
-            rust_object : QObjectPinned<QQuickItem> as "TraitObject",
+            rust_object : QObjectPinned<dyn QQuickItem> as "TraitObject",
             event : QMouseEvent as "QMouseEvent*"
         ] -> bool as "bool" {
             rust_object.borrow_mut().mouse_event(event)
@@ -360,7 +360,7 @@ struct Rust_QQuickItem : RustObject<QQuickItem> {
     virtual void windowDeactivateEvent();*/
     virtual void geometryChanged(const QRectF &new_geometry,
                                  const QRectF &old_geometry) {
-        rust!(Rust_QQuickItem_geometryChanged[rust_object : QObjectPinned<QQuickItem> as "TraitObject",
+        rust!(Rust_QQuickItem_geometryChanged[rust_object : QObjectPinned<dyn QQuickItem> as "TraitObject",
                 new_geometry : QRectF as "QRectF", old_geometry : QRectF as "QRectF"] {
             rust_object.borrow_mut().geometry_changed(new_geometry, old_geometry);
         });
@@ -368,7 +368,7 @@ struct Rust_QQuickItem : RustObject<QQuickItem> {
     }
 
     QSGNode *updatePaintNode(QSGNode *node, UpdatePaintNodeData *) override {
-        return rust!(Rust_QQuickItem_updatePaintNode[rust_object : QObjectPinned<QQuickItem> as "TraitObject",
+        return rust!(Rust_QQuickItem_updatePaintNode[rust_object : QObjectPinned<dyn QQuickItem> as "TraitObject",
                     node : *mut c_void as "QSGNode*"] -> SGNode<ContainerNode> as "QSGNode*" {
             rust_object.borrow_mut().update_paint_node(unsafe { SGNode::<ContainerNode>::from_raw(node) })
         });
@@ -382,7 +382,7 @@ struct Rust_QQuickItem : RustObject<QQuickItem> {
 
 }}
 
-impl<'a> QQuickItem + 'a {
+impl<'a> dyn QQuickItem + 'a {
     pub fn bounding_rect(&self) -> QRectF {
         let obj = self.get_cpp_object();
         cpp!(unsafe [obj as "Rust_QQuickItem*"] -> QRectF as "QRectF" {
@@ -541,7 +541,7 @@ cpp!{{
 #include <QtQml/QQmlExtensionPlugin>
 struct Rust_QQmlExtensionPlugin : RustObject<QQmlExtensionPlugin> {
     void registerTypes(const char *uri) override  {
-        rust!(Rust_QQmlExtensionPlugin_registerTypes[rust_object : QObjectPinned<QQmlExtensionPlugin> as "TraitObject",
+        rust!(Rust_QQmlExtensionPlugin_registerTypes[rust_object : QObjectPinned<dyn QQmlExtensionPlugin> as "TraitObject",
                                                             uri : *const std::os::raw::c_char as "const char*"] {
             rust_object.borrow_mut().register_types(unsafe { std::ffi::CStr::from_ptr(uri) });
         });

--- a/qmetaobject/src/scenegraph.rs
+++ b/qmetaobject/src/scenegraph.rs
@@ -356,7 +356,7 @@ impl SGNode<RectangleNode> {
         });
     }
 
-    pub fn create(&mut self, item: &QQuickItem) {
+    pub fn create(&mut self, item: &dyn QQuickItem) {
         if !self.raw.is_null() {
             return;
         }

--- a/qmetaobject/tests/tests.rs
+++ b/qmetaobject/tests/tests.rs
@@ -490,7 +490,7 @@ fn connect_cpp_signal() {
         )
     };
     assert!(con.is_valid());
-    (&*f.borrow() as &QObject).set_object_name("YOYO".into());
+    (&*f.borrow() as &dyn QObject).set_object_name("YOYO".into());
     assert_eq!(result, Some("YOYO".into()));
 }
 
@@ -558,8 +558,8 @@ fn qpointer() {
         obj.push(XX("foo".into()));
         let obj = RefCell::new(obj);
         unsafe { QObjectPinned::new(&obj).get_or_create_cpp_object() };
-        let obj_ref: &qmetaobject::listmodel::QAbstractListModel = &*obj.borrow();
-        ptr = QPointer::<qmetaobject::listmodel::QAbstractListModel>::from(obj_ref);
+        let obj_ref: &dyn qmetaobject::listmodel::QAbstractListModel = &*obj.borrow();
+        ptr = QPointer::<dyn qmetaobject::listmodel::QAbstractListModel>::from(obj_ref);
         pt2 = ptr.clone();
         assert_eq!(ptr.as_ref().map_or(898, |x| x.row_count()), 1);
         assert_eq!(pt2.as_ref().map_or(898, |x| x.row_count()), 1);

--- a/qmetaobject_impl/src/qobject_impl.rs
+++ b/qmetaobject_impl/src/qobject_impl.rs
@@ -799,8 +799,8 @@ pub fn generate(input: TokenStream, is_qobject: bool) -> TokenStream {
                 assert!(pinned.borrow().#base_prop.get().is_null());
                 let object_ptr = #crate_::QObjectPinned::<#crate_::QObject>::new(pinned as &::std::cell::RefCell<#crate_::QObject>);
                 let object_ptr_ptr : *const #crate_::QObjectPinned<#crate_::QObject> = &object_ptr;
-                let rust_pinned = #crate_::QObjectPinned::<#base>::new(pinned as &::std::cell::RefCell<#base>);
-                let rust_pinned_ptr : *const #crate_::QObjectPinned<#base> = &rust_pinned;
+                let rust_pinned = #crate_::QObjectPinned::<dyn #base>::new(pinned as &::std::cell::RefCell<dyn #base>);
+                let rust_pinned_ptr : *const #crate_::QObjectPinned<dyn #base> = &rust_pinned;
                 let n = (<#name #ty_generics as #base>::get_object_description().create)
                     (rust_pinned_ptr as *const ::std::os::raw::c_void, object_ptr_ptr as *const ::std::os::raw::c_void);
                 pinned.borrow_mut().#base_prop.set(n);
@@ -812,8 +812,8 @@ pub fn generate(input: TokenStream, is_qobject: bool) -> TokenStream {
 
                 let object_ptr = #crate_::QObjectPinned::<#crate_::QObject>::new(pinned as &::std::cell::RefCell<#crate_::QObject>);
                 let object_ptr_ptr : *const #crate_::QObjectPinned<#crate_::QObject> = &object_ptr;
-                let rust_pinned = #crate_::QObjectPinned::<#base>::new(pinned as &::std::cell::RefCell<#base>);
-                let rust_pinned_ptr : *const #crate_::QObjectPinned<#base> = &rust_pinned;
+                let rust_pinned = #crate_::QObjectPinned::<dyn #base>::new(pinned as &::std::cell::RefCell<dyn #base>);
+                let rust_pinned_ptr : *const #crate_::QObjectPinned<dyn #base> = &rust_pinned;
                 pinned.borrow_mut().#base_prop.set(mem);
                 (<#name #ty_generics as #base>::get_object_description().qml_construct)(
                     mem, rust_pinned_ptr as *const ::std::os::raw::c_void,


### PR DESCRIPTION
I could only build `todos` example though; not sure what to do with the others.