### PR TITLE
Create a wrapper around QQmlComponent

### DIFF
--- a/qmetaobject/Cargo.toml
+++ b/qmetaobject/Cargo.toml
@@ -25,6 +25,7 @@ cpp_build = "0.5"
 [dev-dependencies]
 cstr = "0.1"
 if_rust_version = "1"
+tempfile = "^3"
 
 
 [package.metadata.docs.rs]

--- a/qmetaobject/qmetaobject_rust.hpp
+++ b/qmetaobject/qmetaobject_rust.hpp
@@ -29,8 +29,8 @@ union SignalCppRepresentation {
 
     // Construct the object from an arbirary signal.
     // (there is a double indirection in the reinterpret_cast to avoid -Wcast-function-type)
-    template<typename R, typename ...Args>
-    SignalCppRepresentation(R (QObject::*cpp_signal)(Args...))
+    template<typename R, typename Object, typename ...Args>
+    SignalCppRepresentation(R (Object::*cpp_signal)(Args...))
         : cpp_signal(*reinterpret_cast<void (QObject::**)()>(&cpp_signal)) { }
 };
 


### PR DESCRIPTION
Support setData and loadUrl methods
Fix SignalCppRepresentation to support classes other than QObject