### PR TITLE
Avoid using impl dyn

### DIFF
--- a/qmetaobject/Cargo.toml
+++ b/qmetaobject/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qmetaobject"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2018"
 authors = ["Olivier Goffart <ogoffart@woboq.com>"]
 build = "build.rs"

--- a/qmetaobject/Cargo.toml
+++ b/qmetaobject/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/woboq/qmetaobject-rs"
 chrono_qdatetime = ["chrono"]
 
 [dependencies]
-qmetaobject_impl = { path = "../qmetaobject_impl", version = "=0.1.3"}
+qmetaobject_impl = { path = "../qmetaobject_impl", version = "=0.2.0"}
 lazy_static = "1.0"
 cpp = "0.5"
 chrono = { version = "0.4", optional = true }

--- a/qmetaobject/src/itemmodel.rs
+++ b/qmetaobject/src/itemmodel.rs
@@ -51,46 +51,43 @@ pub trait QAbstractItemModel: QObject {
     fn role_names(&self) -> HashMap<i32, QByteArray> {
         HashMap::new()
     }
-}
-
-impl dyn QAbstractItemModel {
     /// Refer to the Qt documentation of QAbstractListModel::beginInsertRows
-    pub fn begin_insert_rows(&self, parent: QModelIndex, first: i32, last: i32) {
+    fn begin_insert_rows(&self, parent: QModelIndex, first: i32, last: i32) {
         let obj = self.get_cpp_object();
         cpp!(unsafe [obj as "Rust_QAbstractItemModel*", parent as "QModelIndex", first as "int", last as "int"]{
             if(obj) obj->beginInsertRows(parent, first, last);
         })
     }
     /// Refer to the Qt documentation of QAbstractListModel::endInsertRows
-    pub fn end_insert_rows(&self) {
+    fn end_insert_rows(&self) {
         let obj = self.get_cpp_object();
         cpp!(unsafe [obj as "Rust_QAbstractItemModel*"]{
             if(obj) obj->endInsertRows();
         })
     }
     /// Refer to the Qt documentation of QAbstractListModel::beginRemoveRows
-    pub fn begin_remove_rows(&self, parent: QModelIndex, first: i32, last: i32) {
+    fn begin_remove_rows(&self, parent: QModelIndex, first: i32, last: i32) {
         let obj = self.get_cpp_object();
         cpp!(unsafe [obj as "Rust_QAbstractItemModel*", parent as "QModelIndex", first as "int", last as "int"]{
             if(obj) obj->beginRemoveRows(parent, first, last);
         })
     }
     /// Refer to the Qt documentation of QAbstractListModel::endRemoveRows
-    pub fn end_remove_rows(&self) {
+    fn end_remove_rows(&self) {
         let obj = self.get_cpp_object();
         cpp!(unsafe [obj as "Rust_QAbstractItemModel*"]{
             if(obj) obj->endRemoveRows();
         })
     }
     /// Refer to the Qt documentation of QAbstractListModel::beginResetModel
-    pub fn begin_reset_model(&self) {
+    fn begin_reset_model(&self) {
         let obj = self.get_cpp_object();
         cpp!(unsafe [obj as "Rust_QAbstractItemModel*"]{
             if(obj) obj->beginResetModel();
         })
     }
     /// Refer to the Qt documentation of QAbstractListModel::endResetModel
-    pub fn end_reset_model(&self) {
+    fn end_reset_model(&self) {
         let obj = self.get_cpp_object();
         cpp!(unsafe [obj as "Rust_QAbstractItemModel*"]{
             if(obj) obj->endResetModel();
@@ -100,7 +97,7 @@ impl dyn QAbstractItemModel {
     /// Refer to the Qt documentation of QAbstractListModel::layoutAboutToBeChanged
     ///
     /// update_model_indexes need to be called between layout_about_to_be_changed and layout_changed
-    pub fn layout_about_to_be_changed(&self) {
+    fn layout_about_to_be_changed(&self) {
         let obj = self.get_cpp_object();
         cpp!(unsafe [obj as "Rust_QAbstractItemModel*"] {
             if (obj) obj->layoutAboutToBeChanged();
@@ -110,11 +107,8 @@ impl dyn QAbstractItemModel {
     /// Refer to the Qt documentation of QAbstractListModel::layoutAboutToBeChanged
     ///
     /// update_model_indexes need to be called between layout_about_to_be_changed and layout_changed
-    pub fn update_model_indexes<F>(&self, mut f: F)
-    where
-        F: FnMut(QModelIndex) -> QModelIndex,
+    fn update_model_indexes(&self, f: &mut dyn FnMut(QModelIndex) -> QModelIndex)
     {
-        let f: &mut dyn FnMut(QModelIndex) -> QModelIndex = &mut f;
         let obj = self.get_cpp_object();
         cpp!(unsafe [obj as "Rust_QAbstractItemModel*", f as "TraitObject"] {
             if (!obj) return;
@@ -132,7 +126,7 @@ impl dyn QAbstractItemModel {
     /// Refer to the Qt documentation of QAbstractListModel::layoutChanged
     ///
     /// update_model_indexes need to be called between layout_about_to_be_changed and layout_changed
-    pub fn layout_changed(&self) {
+    fn layout_changed(&self) {
         let obj = self.get_cpp_object();
         cpp!(unsafe [obj as "Rust_QAbstractItemModel*"] {
             if (obj) obj->layoutChanged();
@@ -140,7 +134,7 @@ impl dyn QAbstractItemModel {
     }
 
     /// Refer to the Qt documentation of QAbstractListModel::dataChanged
-    pub fn data_changed(&self, top_left: QModelIndex, bottom_right: QModelIndex) {
+    fn data_changed(&self, top_left: QModelIndex, bottom_right: QModelIndex) {
         let obj = self.get_cpp_object();
         cpp!(unsafe [obj as "Rust_QAbstractItemModel*", top_left as "QModelIndex", bottom_right as "QModelIndex"]{
             if(obj) obj->dataChanged(top_left, bottom_right);
@@ -148,7 +142,7 @@ impl dyn QAbstractItemModel {
     }
 
     /// Refer to the Qt documentation of QAbstractItemModel::createIndex
-    pub fn create_index(&self, row: i32, column: i32, id: usize) -> QModelIndex {
+    fn create_index(&self, row: i32, column: i32, id: usize) -> QModelIndex {
         let obj = self.get_cpp_object();
         cpp!(unsafe [obj as "Rust_QAbstractItemModel*", row as "int", column as "int", id as "uintptr_t"] -> QModelIndex as "QModelIndex" {
             return obj ? obj->createIndex(row, column, id) : QModelIndex();

--- a/qmetaobject/src/listmodel.rs
+++ b/qmetaobject/src/listmodel.rs
@@ -47,12 +47,9 @@ pub trait QAbstractListModel: QObject {
     fn role_names(&self) -> HashMap<i32, QByteArray> {
         HashMap::new()
     }
-}
 
-// FIXME! code duplication with impl QAbstractItemModel
-impl dyn QAbstractListModel {
     /// Refer to the Qt documentation of QAbstractListModel::beginInsertRows
-    pub fn begin_insert_rows(&mut self, first: i32, last: i32) {
+    fn begin_insert_rows(&mut self, first: i32, last: i32) {
         let p = QModelIndex::default();
         let obj = self.get_cpp_object();
         unsafe {
@@ -62,7 +59,7 @@ impl dyn QAbstractListModel {
         }
     }
     /// Refer to the Qt documentation of QAbstractListModel::endInsertRows
-    pub fn end_insert_rows(&mut self) {
+    fn end_insert_rows(&mut self) {
         let obj = self.get_cpp_object();
         unsafe {
             cpp!([obj as "Rust_QAbstractListModel*"]{
@@ -71,7 +68,7 @@ impl dyn QAbstractListModel {
         }
     }
     /// Refer to the Qt documentation of QAbstractListModel::beginRemoveRows
-    pub fn begin_remove_rows(&mut self, first: i32, last: i32) {
+    fn begin_remove_rows(&mut self, first: i32, last: i32) {
         let p = QModelIndex::default();
         let obj = self.get_cpp_object();
         unsafe {
@@ -81,7 +78,7 @@ impl dyn QAbstractListModel {
         }
     }
     /// Refer to the Qt documentation of QAbstractListModel::endRemoveRows
-    pub fn end_remove_rows(&mut self) {
+    fn end_remove_rows(&mut self) {
         let obj = self.get_cpp_object();
         unsafe {
             cpp!([obj as "Rust_QAbstractListModel*"]{
@@ -90,7 +87,7 @@ impl dyn QAbstractListModel {
         }
     }
     /// Refer to the Qt documentation of QAbstractListModel::beginResetModel
-    pub fn begin_reset_model(&mut self) {
+    fn begin_reset_model(&mut self) {
         let obj = self.get_cpp_object();
         unsafe {
             cpp!([obj as "Rust_QAbstractListModel*"]{
@@ -99,7 +96,7 @@ impl dyn QAbstractListModel {
         }
     }
     /// Refer to the Qt documentation of QAbstractListModel::endResetModel
-    pub fn end_reset_model(&mut self) {
+    fn end_reset_model(&mut self) {
         let obj = self.get_cpp_object();
         unsafe {
             cpp!([obj as "Rust_QAbstractListModel*"]{
@@ -109,7 +106,7 @@ impl dyn QAbstractListModel {
     }
 
     /// Refer to the Qt documentation of QAbstractListModel::dataChanged
-    pub fn data_changed(&mut self, top_left: QModelIndex, bottom_right: QModelIndex) {
+    fn data_changed(&mut self, top_left: QModelIndex, bottom_right: QModelIndex) {
         let obj = self.get_cpp_object();
         unsafe {
             cpp!([obj as "Rust_QAbstractListModel*", top_left as "QModelIndex", bottom_right as "QModelIndex"]{
@@ -119,7 +116,7 @@ impl dyn QAbstractListModel {
     }
 
     /// Returns a QModelIndex for the given row (in the first column)
-    pub fn row_index(&self, i: i32) -> QModelIndex {
+    fn row_index(&self, i: i32) -> QModelIndex {
         let obj = self.get_cpp_object();
         unsafe {
             cpp!([obj as "Rust_QAbstractListModel*", i as "int"] -> QModelIndex as "QModelIndex" {

--- a/qmetaobject_impl/Cargo.toml
+++ b/qmetaobject_impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qmetaobject_impl"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2018"
 authors = ["Olivier Goffart <ogoffart@woboq.com>"]
 description = "Custom derive for the qmetaobject crate."


### PR DESCRIPTION
`impl dyn` methods taking `self` by reference imply the `+'static` lifetime on the `self` reference. If the object implementing the trait has a custom lifetime the `impl dyn` methods cannot be used.

It is also illegal to have a generic method on a trait object, so `update_model_indexes` was modified to take the `FnMut` parameter by reference and without using a generic parameter.