### PR TITLE
Support building on macOS with official Qt distributions

### DIFF
--- a/qmetaobject/build.rs
+++ b/qmetaobject/build.rs
@@ -33,10 +33,14 @@ fn qmake_query(var: &str) -> String {
 fn main() {
     let qt_include_path = qmake_query("QT_INSTALL_HEADERS");
     let qt_library_path = qmake_query("QT_INSTALL_LIBS");
+    let mut config = cpp_build::Config::new();
 
-    cpp_build::Config::new()
-        .include(qt_include_path.trim())
-        .build("src/lib.rs");
+    if cfg!(target_os = "macos") {
+        config.flag("-F");
+        config.flag(qt_library_path.trim());
+    }
+
+    config.include(qt_include_path.trim()).build("src/lib.rs");
 
     let macos_lib_search = if cfg!(target_os = "macos") {
         "=framework"


### PR DESCRIPTION
The Homebrew builds of Qt use symlinks in `/usr/local/Cellar/qt/5.xx/include` back to the framework headers in the `/usr/local/Cellar/qt/5.xx/lib` folder.

These symlinks don't exist in the official Qt distributions. As a result the builds fail, being unable to locate any Qt headers. Passing `-F` will cause the compiler to search for frameworks and their associated headers in the Qt library folder.

Homebrew builds still work after this change.