### PR TITLE
implement QMetaType for QUrl and add QUrl::from_user_input method

### DIFF
--- a/qmetaobject/src/qmetatype.rs
+++ b/qmetaobject/src/qmetatype.rs
@@ -228,6 +228,9 @@ macro_rules! qdeclare_builtin_metatype {
         }
     };
 }
+
+// See https://doc.qt.io/qt-5/qmetatype.html#Type-enum
+
 qdeclare_builtin_metatype! {()   => 43}
 qdeclare_builtin_metatype! {bool => 1}
 qdeclare_builtin_metatype! {i32  => 2}
@@ -247,6 +250,7 @@ qdeclare_builtin_metatype! {QByteArray => 12}
 qdeclare_builtin_metatype! {QDate => 14}
 qdeclare_builtin_metatype! {QTime => 15}
 qdeclare_builtin_metatype! {QDateTime => 16}
+qdeclare_builtin_metatype! {QUrl => 17}
 qdeclare_builtin_metatype! {QRectF => 20}
 qdeclare_builtin_metatype! {QPointF => 26}
 //qdeclare_builtin_metatype!{QVariant => 41}

--- a/qmetaobject/src/qttypes.rs
+++ b/qmetaobject/src/qttypes.rs
@@ -402,6 +402,21 @@ cpp_class!(
     #[derive(PartialEq, PartialOrd, Eq, Ord)]
     pub unsafe struct QUrl as "QUrl"
 );
+
+impl QUrl {
+    /// Returns a valid URL from a user supplied qstring if one can be deducted.
+    /// In the case that is not possible, an invalid QUrl is returned.
+    /// 
+    /// Refer to the documentation for QUrl::fromUserInput.
+    pub fn from_user_input(qstring: QString) -> QUrl {
+        unsafe {
+            cpp!([qstring as "QString"] -> QUrl as "QUrl" {
+                return QUrl::fromUserInput(qstring);
+            })
+        }
+    }
+}
+
 impl From<QString> for QUrl {
     fn from(qstring: QString) -> QUrl {
         unsafe { cpp!([qstring as "QString"] -> QUrl as "QUrl" {
@@ -503,6 +518,13 @@ impl From<QDateTime> for QVariant {
         unsafe { cpp!([a as "QDateTime"] -> QVariant as "QVariant" { return QVariant(a); }) }
     }
 }
+
+impl From<QUrl> for QVariant {
+    fn from(a: QUrl) -> QVariant {
+        unsafe { cpp!([a as "QUrl"] -> QVariant as "QVariant" { return QVariant(a); }) }
+    }
+}
+
 impl From<QVariantList> for QVariant {
     fn from(a: QVariantList) -> QVariant {
         unsafe { cpp!([a as "QVariantList"] -> QVariant as "QVariant" { return QVariant(a); }) }


### PR DESCRIPTION
This allows `QUrl` values to be used as properties or parameters to methods or signals.

Also the addition of `QUrl::from_user_input` allows the creation of `QUrl` objects from "user-friendly" strings, such as "github.com".