### PR TITLE
qml_register singleton

### DIFF
--- a/qmetaobject/Cargo.toml
+++ b/qmetaobject/Cargo.toml
@@ -21,6 +21,7 @@ chrono = { version = "0.4", optional = true }
 
 [build-dependencies]
 cpp_build = "0.5.4"
+semver = "0.9"
 
 [dev-dependencies]
 cstr = "0.1"

--- a/qmetaobject/build.rs
+++ b/qmetaobject/build.rs
@@ -17,6 +17,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 extern crate cpp_build;
 use std::process::Command;
+use semver::Version;
 
 fn qmake_query(var: &str) -> String {
     String::from_utf8(
@@ -33,6 +34,7 @@ fn qmake_query(var: &str) -> String {
 fn main() {
     let qt_include_path = qmake_query("QT_INSTALL_HEADERS");
     let qt_library_path = qmake_query("QT_INSTALL_LIBS");
+    let qt_version = qmake_query("QT_VERSION").parse::<Version>().expect("Parsing Qt version failed");
     let mut config = cpp_build::Config::new();
 
     if cfg!(target_os = "macos") {
@@ -74,4 +76,8 @@ fn main() {
         "cargo:rustc-link-lib{}=Qt{}Qml",
         macos_lib_search, macos_lib_framework
     );
+
+    if qt_version >= Version::new(5, 14, 0) {
+        println!("cargo:rustc-cfg=qt_5_14");
+    }
 }

--- a/qmetaobject/build.rs
+++ b/qmetaobject/build.rs
@@ -45,7 +45,6 @@ fn main() {
     }
 
     if qt_version >= Version::new(5, 14, 0) {
-        config.define("QT_5_14", None);
         println!("cargo:rustc-cfg=qt_5_14");
     }
 

--- a/qmetaobject/build.rs
+++ b/qmetaobject/build.rs
@@ -16,8 +16,8 @@ OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 extern crate cpp_build;
-use std::process::Command;
 use semver::Version;
+use std::process::Command;
 
 fn qmake_query(var: &str) -> String {
     String::from_utf8(
@@ -34,7 +34,9 @@ fn qmake_query(var: &str) -> String {
 fn main() {
     let qt_include_path = qmake_query("QT_INSTALL_HEADERS");
     let qt_library_path = qmake_query("QT_INSTALL_LIBS");
-    let qt_version = qmake_query("QT_VERSION").parse::<Version>().expect("Parsing Qt version failed");
+    let qt_version = qmake_query("QT_VERSION")
+        .parse::<Version>()
+        .expect("Parsing Qt version failed");
     let mut config = cpp_build::Config::new();
 
     if cfg!(target_os = "macos") {
@@ -45,7 +47,7 @@ fn main() {
     if qt_version >= Version::new(5, 14, 0) {
         config.define("QT_5_14", None);
         println!("cargo:rustc-cfg=qt_5_14");
-    }    
+    }
 
     config.include(qt_include_path.trim()).build("src/lib.rs");
 

--- a/qmetaobject/build.rs
+++ b/qmetaobject/build.rs
@@ -42,6 +42,11 @@ fn main() {
         config.flag(qt_library_path.trim());
     }
 
+    if qt_version >= Version::new(5, 14, 0) {
+        config.define("QT_5_14", None);
+        println!("cargo:rustc-cfg=qt_5_14");
+    }    
+
     config.include(qt_include_path.trim()).build("src/lib.rs");
 
     let macos_lib_search = if cfg!(target_os = "macos") {
@@ -76,8 +81,4 @@ fn main() {
         "cargo:rustc-link-lib{}=Qt{}Qml",
         macos_lib_search, macos_lib_framework
     );
-
-    if qt_version >= Version::new(5, 14, 0) {
-        println!("cargo:rustc-cfg=qt_5_14");
-    }
 }

--- a/qmetaobject/src/qtdeclarative.rs
+++ b/qmetaobject/src/qtdeclarative.rs
@@ -458,8 +458,10 @@ pub fn qml_register_singleton<T: QObject + Sized + Default>(
     unsafe {
         cpp!([uri_ptr as "char*", version_major as "int", version_minor as "int", 
                 type_name_ptr as "char*", obj_ptr as "QObject*"] {
+            #ifdef QT_5_14
             qmlRegisterSingletonInstance(uri_ptr, version_major, version_minor, type_name_ptr,
                 obj_ptr);
+            #endif
         })
     }
     

--- a/qmetaobject/src/qtdeclarative.rs
+++ b/qmetaobject/src/qtdeclarative.rs
@@ -509,6 +509,9 @@ pub fn qml_register_singleton_type<T: QObject + Sized + Default, F: Fn() -> T + 
 
 /// Register the passed object as a singleton QML object.
 ///
+/// As there is currently no method to unregister a singleton object, the
+/// passed object is leaked and cannot be dropped.
+/// 
 /// The object is shared between all instances of `QmlEngine`.
 ///
 /// Refer to the Qt documentation for qmlRegisterSingletonInstance.

--- a/qmetaobject/src/qtdeclarative.rs
+++ b/qmetaobject/src/qtdeclarative.rs
@@ -455,12 +455,13 @@ pub trait QSingletonInit {
 /// Register the specified type as a singleton QML object.
 ///
 /// A new object will be default-constructed for each new instance of `QmlEngine`.
-/// After construction the QSingleInit::init() function will be called on the object.
+/// After construction of the corresponding C++ object the `QSingletonInit::init()` function 
+/// will be called.
 ///
 /// Refer to the Qt documentation for qmlRegisterSingletonType.
 ///
 /// # Panics
-/// The process will be aborted when the T::default() or T::init() method panics.
+/// The process will be aborted when the default or init functions panic.
 pub fn qml_register_singleton_type<T: QObject + QSingletonInit + Sized + Default>(
     uri: &std::ffi::CStr,
     version_major: u32,

--- a/qmetaobject/src/qtdeclarative.rs
+++ b/qmetaobject/src/qtdeclarative.rs
@@ -436,6 +436,31 @@ pub fn qml_register_type<T: QObject + Default + Sized>(
     }
 }
 
+/// Register a default-constructed object of specified type as a singleton QML object.
+/// 
+/// Refer to the Qt documentation for qmlRegisterSingletonInstance.
+pub fn qml_register_singleton<T: QObject + Sized + Default>(
+     uri: &std::ffi::CStr,
+     version_major: u32,
+     version_minor: u32,
+     type_name: &std::ffi::CStr,  
+) {
+    let uri_ptr = uri.as_ptr();
+    let type_name_ptr = type_name.as_ptr();    
+
+    let obj: Box<RefCell<T>> = Box::new(RefCell::new(T::default()));
+    let obj_ptr = unsafe { T::cpp_construct(&obj) };
+    Box::into_raw(obj);
+
+    unsafe {
+        cpp!([uri_ptr as "char*", version_major as "int", version_minor as "int", 
+                type_name_ptr as "char*", obj_ptr as "QObject*"] {
+            qmlRegisterSingletonInstance(uri_ptr, version_major, version_minor, type_name_ptr,
+                obj_ptr);
+        })
+    }
+}
+
 /// Register the given enum as a QML type
 ///
 /// Refer to the Qt documentation for qmlRegisterUncreatableMetaObject.

--- a/qmetaobject/src/qtdeclarative.rs
+++ b/qmetaobject/src/qtdeclarative.rs
@@ -444,12 +444,13 @@ pub fn qml_register_singleton<T: QObject + Sized + Default>(
      version_major: u32,
      version_minor: u32,
      type_name: &std::ffi::CStr,  
-) {
+) -> QPointer<T> {
     let uri_ptr = uri.as_ptr();
     let type_name_ptr = type_name.as_ptr();    
 
     let obj: Box<RefCell<T>> = Box::new(RefCell::new(T::default()));
     let obj_ptr = unsafe { T::cpp_construct(&obj) };
+    let qptr = QPointer::from(&*obj.borrow());
     Box::into_raw(obj);
 
     unsafe {
@@ -459,6 +460,8 @@ pub fn qml_register_singleton<T: QObject + Sized + Default>(
                 obj_ptr);
         })
     }
+    
+    qptr
 }
 
 /// Register the given enum as a QML type

--- a/qmetaobject/src/qtdeclarative.rs
+++ b/qmetaobject/src/qtdeclarative.rs
@@ -443,10 +443,10 @@ cpp! {{
 /// Initialization for singleton QML objects.
 pub trait QSingletonInit {
     /// Initialize the singleton QML object.
-    /// 
+    ///
     /// Will be called on a default-constructed object after the C++ object
     /// has been created.
-    /// 
+    ///
     /// # Panics
     /// The process will be aborted when the method panics.
     fn init(&mut self);

--- a/qmetaobject/src/qtdeclarative.rs
+++ b/qmetaobject/src/qtdeclarative.rs
@@ -436,12 +436,53 @@ pub fn qml_register_type<T: QObject + Default + Sized>(
     }
 }
 
+cpp! {{
+    typedef QObject *(*QmlRegisterSingletonTypeCallback)(QQmlEngine *, QJSEngine *);
+}}
+
 /// Register a default-constructed object of specified type as a singleton QML object.
+/// 
+/// A new object will be created for each new instance of `QmlEngine`.
+/// 
+/// Refer to the Qt documentation for qmlRegisterSingletonType.
+pub fn qml_register_singleton_type<T: QObject + Sized + Default>(
+     uri: &std::ffi::CStr,
+     version_major: u32,
+     version_minor: u32,
+     type_name: &std::ffi::CStr,  
+) {
+    let uri_ptr = uri.as_ptr();
+    let type_name_ptr = type_name.as_ptr();    
+
+    extern "C" fn callback_fn<T: QObject + Default + Sized>(_qml_engine: *mut c_void, _js_engine: *mut c_void) -> *mut c_void {
+        let obj: Box<RefCell<T>> = Box::new(RefCell::new(T::default()));
+        let obj_ptr = unsafe { T::cpp_construct(&obj) };
+        Box::into_raw(obj);
+        obj_ptr
+    };
+    let callback_fn: extern "C" fn(_qml_engine: *mut c_void, _js_engine: *mut c_void) -> *mut c_void = callback_fn::<T>;
+
+    unsafe {
+        cpp!([uri_ptr as "const char*", version_major as "int", version_minor as "int", 
+                type_name_ptr as "const char*", callback_fn as "QmlRegisterSingletonTypeCallback"] {
+            qmlRegisterSingletonType<QObject>(uri_ptr, version_major, version_minor, type_name_ptr,
+                callback_fn);
+        })
+    }
+}
+
+
+/// Register a default-constructed object of specified type as a singleton QML object.
+/// 
+/// The object is shared between all instances of `QmlEngine`.
+/// 
+/// Returns a QPointer to the newly constructed singleton object. It can be used
+/// to modify the state of the object before the QML engine is started.
 /// 
 /// Refer to the Qt documentation for qmlRegisterSingletonInstance.
 /// Only avaiable in Qt 5.14 or above. 
 #[cfg(qt_5_14)]
-pub fn qml_register_singleton<T: QObject + Sized + Default>(
+pub fn qml_register_singleton_instance<T: QObject + Sized + Default>(
      uri: &std::ffi::CStr,
      version_major: u32,
      version_minor: u32,

--- a/qmetaobject/src/qtdeclarative.rs
+++ b/qmetaobject/src/qtdeclarative.rs
@@ -503,9 +503,9 @@ pub fn qml_register_singleton_type<T: QObject + Sized + Default>(
                 meta_object);
 
             QQmlPrivate::RegisterSingletonType api = {
-                QmlCurrentSingletonTypeRegistrationVersion,
+                2, // version
                 uri_ptr, version_major, version_minor, qml_name_ptr,
-                nullptr, nullptr, meta_object, ptrType, 0, callback_fn
+                nullptr, callback_fn, meta_object, ptrType, 0
             };
 
             QQmlPrivate::qmlregister(QQmlPrivate::SingletonRegistration, &api);

--- a/qmetaobject/src/qtdeclarative.rs
+++ b/qmetaobject/src/qtdeclarative.rs
@@ -439,6 +439,8 @@ pub fn qml_register_type<T: QObject + Default + Sized>(
 /// Register a default-constructed object of specified type as a singleton QML object.
 /// 
 /// Refer to the Qt documentation for qmlRegisterSingletonInstance.
+/// Only avaiable in Qt 5.14 or above. 
+#[cfg(qt_5_14)]
 pub fn qml_register_singleton<T: QObject + Sized + Default>(
      uri: &std::ffi::CStr,
      version_major: u32,

--- a/qmetaobject/src/qtdeclarative.rs
+++ b/qmetaobject/src/qtdeclarative.rs
@@ -531,7 +531,7 @@ pub fn qml_register_singleton_instance<T: QObject + Sized + Default>(
     unsafe {
         cpp!([uri_ptr as "char*", version_major as "int", version_minor as "int",
                 type_name_ptr as "char*", obj_ptr as "QObject*"] {
-            #ifdef QT_5_14
+            #if QT_VERSION >= QT_VERSION_CHECK(5,14,0)
             qmlRegisterSingletonInstance(uri_ptr, version_major, version_minor, type_name_ptr,
                 obj_ptr);
             #endif

--- a/qmetaobject/tests/tests.rs
+++ b/qmetaobject/tests/tests.rs
@@ -225,26 +225,18 @@ fn register_singleton_instance() {
     ));
 }
 
-#[derive(Default, QObject)]
+#[derive(QObject)]
 struct RegisterSingletonTypeObj {
     base: qt_base_class!(trait QObject),
     value: u32,
     get_value2: qt_method!(fn get_value2(&self) -> u32 { self.value } ),
 }
 
-impl RegisterSingletonTypeObj {
-    fn new() -> Self {
+impl Default for RegisterSingletonTypeObj {
+    fn default() -> Self {
         Self {
             base: Default::default(),
             value: 456,
-            get_value2: Default::default(),
-        }
-    }
-
-    fn new2() -> Self {
-        Self {
-            base: Default::default(),
-            value: 789,
             get_value2: Default::default(),
         }
     }
@@ -252,19 +244,11 @@ impl RegisterSingletonTypeObj {
 
 #[test]
 fn register_singleton_type() {
-    qml_register_singleton_type(
+    qml_register_singleton_type::<RegisterSingletonTypeObj>(
         CStr::from_bytes_with_nul(b"TestRegister\0").unwrap(),
         1,
         0,
         CStr::from_bytes_with_nul(b"RegisterSingletonTypeObj\0").unwrap(),
-        RegisterSingletonTypeObj::new,
-    );
-    qml_register_singleton_type(
-        CStr::from_bytes_with_nul(b"TestRegister\0").unwrap(),
-        1,
-        0,
-        CStr::from_bytes_with_nul(b"RegisterSingletonTypeObj2\0").unwrap(),
-        RegisterSingletonTypeObj::new2,
     );
 
     let obj = MyObject::default(); // not used but needed for do_test
@@ -273,10 +257,7 @@ fn register_singleton_type() {
         "import TestRegister 1.0;
         Item {
             function doTest() {
-                console.log(\"1 is \" + RegisterSingletonTypeObj.get_value2());
-                console.log(\"2 is \" + RegisterSingletonTypeObj2.get_value2());
-                return RegisterSingletonTypeObj.get_value2() === 456 &&
-                    RegisterSingletonTypeObj2.get_value2() === 789;
+                return RegisterSingletonTypeObj.get_value2() === 456;
             }
         }"
     ));

--- a/qmetaobject/tests/tests.rs
+++ b/qmetaobject/tests/tests.rs
@@ -232,14 +232,40 @@ struct RegisterSingletonTypeObj {
     get_value2: qt_method!(fn get_value2(&self) -> u32 { self.value } ),
 }
 
+impl RegisterSingletonTypeObj {
+    fn new() -> Self {
+        Self {
+            base: Default::default(),
+            value: 456,
+            get_value2: Default::default(),
+        }
+    }
+
+    fn new2() -> Self {
+        Self {
+            base: Default::default(),
+            value: 789,
+            get_value2: Default::default(),
+        }
+    }    
+}
+
 #[test]
 fn register_singleton_type() {
-    qml_register_singleton_type::<RegisterSingletonTypeObj>(
+    qml_register_singleton_type(
         CStr::from_bytes_with_nul(b"TestRegister\0").unwrap(),
         1,
         0,
         CStr::from_bytes_with_nul(b"RegisterSingletonTypeObj\0").unwrap(),
+        RegisterSingletonTypeObj::new
     );
+    qml_register_singleton_type(
+        CStr::from_bytes_with_nul(b"TestRegister\0").unwrap(),
+        1,
+        0,
+        CStr::from_bytes_with_nul(b"RegisterSingletonTypeObj2\0").unwrap(),
+        RegisterSingletonTypeObj::new2
+    );    
 
     let obj = MyObject::default(); // not used but needed for do_test
     assert!(do_test(
@@ -247,7 +273,10 @@ fn register_singleton_type() {
         "import TestRegister 1.0;
         Item {
             function doTest() {
-                return RegisterSingletonTypeObj.get_value2() === 0;
+                console.log(\"1 is \" + RegisterSingletonTypeObj.get_value2());
+                console.log(\"2 is \" + RegisterSingletonTypeObj2.get_value2());
+                return RegisterSingletonTypeObj.get_value2() === 456 &&
+                    RegisterSingletonTypeObj2.get_value2() === 789;
             }
         }"
     ));

--- a/qmetaobject/tests/tests.rs
+++ b/qmetaobject/tests/tests.rs
@@ -193,6 +193,66 @@ fn register_type() {
     ));
 }
 
+#[derive(Default, QObject)]
+struct RegisterSingletonInstanceObj {
+    base: qt_base_class!(trait QObject),
+    value: u32,
+    get_value: qt_method!(fn get_value(&self) -> u32 { self.value } ),
+}
+
+#[test]
+fn register_singleton_instance() {
+    let singleton = qml_register_singleton_instance::<RegisterSingletonInstanceObj>(
+        CStr::from_bytes_with_nul(b"TestRegister\0").unwrap(),
+        1,
+        0,
+        CStr::from_bytes_with_nul(b"RegisterSingletonInstanceObj\0").unwrap(),
+    );
+    singleton.as_pinned().unwrap().borrow_mut().value = 123;
+
+    let obj = MyObject::default(); // not used but needed for do_test
+    assert!(do_test(
+        obj,
+        "import TestRegister 1.0;
+        Item {
+            function doTest() {
+                return RegisterSingletonInstanceObj.get_value() === 123;
+            }
+        }"
+    ));
+}
+
+
+#[derive(Default, QObject)]
+struct RegisterSingletonTypeObj {
+    base: qt_base_class!(trait QObject),
+    value: u32,
+    get_value2: qt_method!(fn get_value2(&self) -> u32 { self.value } ),
+}
+
+#[test]
+fn register_singleton_type() {
+    qml_register_singleton_type::<RegisterSingletonTypeObj>(
+        CStr::from_bytes_with_nul(b"TestRegister\0").unwrap(),
+        1,
+        0,
+        CStr::from_bytes_with_nul(b"RegisterSingletonTypeObj\0").unwrap(),
+    );
+
+    let obj = MyObject::default(); // not used but needed for do_test
+    assert!(do_test(
+        obj,
+        "import TestRegister 1.0;
+        Item {
+            function doTest() {
+                return RegisterSingletonTypeObj.get_value2() === 0;
+            }
+        }"
+    ));
+}
+
+
+
 #[test]
 fn simple_gadget() {
     #[derive(Default, Clone, QGadget)]

--- a/qmetaobject/tests/tests.rs
+++ b/qmetaobject/tests/tests.rs
@@ -201,6 +201,7 @@ struct RegisterSingletonInstanceObj {
 }
 
 #[test]
+#[cfg(qt_5_14)]
 fn register_singleton_instance() {
     let singleton = qml_register_singleton_instance::<RegisterSingletonInstanceObj>(
         CStr::from_bytes_with_nul(b"TestRegister\0").unwrap(),

--- a/qmetaobject/tests/tests.rs
+++ b/qmetaobject/tests/tests.rs
@@ -203,13 +203,15 @@ struct RegisterSingletonInstanceObj {
 #[test]
 #[cfg(qt_5_14)]
 fn register_singleton_instance() {
-    let singleton = qml_register_singleton_instance::<RegisterSingletonInstanceObj>(
+    let mut myobj = RegisterSingletonInstanceObj::default();
+    myobj.value = 123;
+    qml_register_singleton_instance(
         CStr::from_bytes_with_nul(b"TestRegister\0").unwrap(),
         1,
         0,
         CStr::from_bytes_with_nul(b"RegisterSingletonInstanceObj\0").unwrap(),
+        myobj
     );
-    singleton.as_pinned().unwrap().borrow_mut().value = 123;
 
     let obj = MyObject::default(); // not used but needed for do_test
     assert!(do_test(

--- a/qmetaobject/tests/tests.rs
+++ b/qmetaobject/tests/tests.rs
@@ -210,7 +210,7 @@ fn register_singleton_instance() {
         1,
         0,
         CStr::from_bytes_with_nul(b"RegisterSingletonInstanceObj\0").unwrap(),
-        myobj
+        myobj,
     );
 
     let obj = MyObject::default(); // not used but needed for do_test
@@ -247,7 +247,7 @@ impl RegisterSingletonTypeObj {
             value: 789,
             get_value2: Default::default(),
         }
-    }    
+    }
 }
 
 #[test]
@@ -257,15 +257,15 @@ fn register_singleton_type() {
         1,
         0,
         CStr::from_bytes_with_nul(b"RegisterSingletonTypeObj\0").unwrap(),
-        RegisterSingletonTypeObj::new
+        RegisterSingletonTypeObj::new,
     );
     qml_register_singleton_type(
         CStr::from_bytes_with_nul(b"TestRegister\0").unwrap(),
         1,
         0,
         CStr::from_bytes_with_nul(b"RegisterSingletonTypeObj2\0").unwrap(),
-        RegisterSingletonTypeObj::new2
-    );    
+        RegisterSingletonTypeObj::new2,
+    );
 
     let obj = MyObject::default(); // not used but needed for do_test
     assert!(do_test(

--- a/qmetaobject/tests/tests.rs
+++ b/qmetaobject/tests/tests.rs
@@ -222,7 +222,6 @@ fn register_singleton_instance() {
     ));
 }
 
-
 #[derive(Default, QObject)]
 struct RegisterSingletonTypeObj {
     base: qt_base_class!(trait QObject),
@@ -250,8 +249,6 @@ fn register_singleton_type() {
         }"
     ));
 }
-
-
 
 #[test]
 fn simple_gadget() {

--- a/qmetaobject/tests/tests.rs
+++ b/qmetaobject/tests/tests.rs
@@ -225,20 +225,16 @@ fn register_singleton_instance() {
     ));
 }
 
-#[derive(QObject)]
+#[derive(QObject, Default)]
 struct RegisterSingletonTypeObj {
     base: qt_base_class!(trait QObject),
     value: u32,
     get_value2: qt_method!(fn get_value2(&self) -> u32 { self.value } ),
 }
 
-impl Default for RegisterSingletonTypeObj {
-    fn default() -> Self {
-        Self {
-            base: Default::default(),
-            value: 456,
-            get_value2: Default::default(),
-        }
+impl QSingletonInit for RegisterSingletonTypeObj {
+    fn init(&mut self) {
+        self.value = 456;
     }
 }
 


### PR DESCRIPTION
Registers a QML singleton object.

This has the same purpose as the C++ qmlRegisterSingletonType function but uses qmlRegisterSingletonInstance, which was introduced in Qt 5.14, to avoid the need for a callback.

I am not sure if ownership and destruction are handled correctly, so please check carefully ;)