### PR TITLE
qreal on 32 bit ARM is 32 bit float

### DIFF
--- a/qmetaobject/Cargo.toml
+++ b/qmetaobject/Cargo.toml
@@ -12,7 +12,6 @@ repository = "https://github.com/woboq/qmetaobject-rs"
 
 [features]
 chrono_qdatetime = ["chrono"]
-qreal-is-float = []
 
 [dependencies]
 qmetaobject_impl = { path = "../qmetaobject_impl", version = "=0.1.4"}

--- a/qmetaobject/Cargo.toml
+++ b/qmetaobject/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/woboq/qmetaobject-rs"
 
 [features]
 chrono_qdatetime = ["chrono"]
+qreal-is-float = []
 
 [dependencies]
 qmetaobject_impl = { path = "../qmetaobject_impl", version = "=0.1.4"}

--- a/qmetaobject/build.rs
+++ b/qmetaobject/build.rs
@@ -47,7 +47,7 @@ fn detect_qreal_size(qt_include_path: &str) {
         let line = line.expect("qconfig.h is valid UTF-8");
         if line.contains("QT_COORD_TYPE") {
             if line.contains("float") {
-                println!("cargo:rustc-cfg=feature=\"qreal-is-float\"");
+                println!("cargo:rustc-cfg=qreal_is_float");
                 return;
             } else {
                 panic!("QT_COORD_TYPE with unknown declaration {}", line);

--- a/qmetaobject/src/qttypes.rs
+++ b/qmetaobject/src/qttypes.rs
@@ -750,11 +750,11 @@ impl QModelIndex {
 }
 
 #[allow(non_camel_case_types)]
-#[cfg(feature = "qreal-is-float")]
+#[cfg(qreal_is_float)]
 type qreal = f32;
 
 #[allow(non_camel_case_types)]
-#[cfg(not(feature = "qreal-is-float"))]
+#[cfg(not(qreal_is_float))]
 type qreal = f64;
 
 /// Wrapper around QRectF

--- a/qmetaobject/src/qttypes.rs
+++ b/qmetaobject/src/qttypes.rs
@@ -750,6 +750,11 @@ impl QModelIndex {
 }
 
 #[allow(non_camel_case_types)]
+#[cfg(all(target_pointer_width = "32", target_arch = "arm"))]
+type qreal = f32;
+
+#[allow(non_camel_case_types)]
+#[cfg(any(target_pointer_width = "64", not(target_arch = "arm")))]
 type qreal = f64;
 
 /// Wrapper around QRectF

--- a/qmetaobject/src/qttypes.rs
+++ b/qmetaobject/src/qttypes.rs
@@ -750,11 +750,11 @@ impl QModelIndex {
 }
 
 #[allow(non_camel_case_types)]
-#[cfg(all(target_pointer_width = "32", target_arch = "arm"))]
+#[cfg(feature = "qreal-is-float")]
 type qreal = f32;
 
 #[allow(non_camel_case_types)]
-#[cfg(any(target_pointer_width = "64", not(target_arch = "arm")))]
+#[cfg(not(feature = "qreal-is-float"))]
 type qreal = f64;
 
 /// Wrapper around QRectF


### PR DESCRIPTION
It seems that [for some platforms, a `qreal` should be `f32`](https://doc.qt.io/qt-5/qtglobal.html#qreal-typedef).  ~~I'm not sure whether the condition I add here is correct, but at least I get it to compile for SailfishOS with (among others) this patch.~~

EDIT: the edited patch checks whether `qconfig.h` contains a definition of `QT_COORD_TYPE`, which is the only possible redefinition of `qreal`.

I've had the same issue on SailfishOS-i486, which reminded me of this outstanding patch. It doesn't have anything to do with being on ARM.

---

On a completely different note: I've [molested `build.rs` and deleted some features in a fork](https://gitlab.com/rubdos/qmetaobject-sfos-rs/-/tree/sailfishos) to support Qt 5.6 with a cross-compiled MerSDK.  When SailfishOS finally decides to migrate to some modern Qt distribution, I hope to upstream a build system with your repo here, but that should obviously be a bit cleaner.