### PR TITLE
Make qmake binary configurable

### DIFF
--- a/qmetaobject/build.rs
+++ b/qmetaobject/build.rs
@@ -16,18 +16,20 @@ OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 extern crate cpp_build;
+
 use std::process::Command;
 
 fn qmake_query(var: &str) -> String {
+    let qmake = std::env::var("QMAKE").unwrap_or("qmake".to_string());
     String::from_utf8(
-        Command::new("qmake")
+        Command::new(qmake)
             .env("QT_SELECT", "qt5")
             .args(&["-query", var])
             .output()
             .expect("Failed to execute qmake. Make sure 'qmake' is in your path")
             .stdout,
     )
-    .expect("UTF-8 conversion failed")
+        .expect("UTF-8 conversion failed")
 }
 
 fn main() {


### PR DESCRIPTION
Make `qmake` binary configurable through env variable. This is needed because some linux distros (I'm looking at you fedora) have it under qmake-qt5 name, since base platform QT is 4 and everything from Qt5 must be marked as such.