### PR TITLE
Fixes, typos and docs

### DIFF
--- a/qmetaobject/qmetaobject_rust.hpp
+++ b/qmetaobject/qmetaobject_rust.hpp
@@ -43,6 +43,12 @@ struct TraitObject {
 extern "C" QMetaObject *RustObject_metaObject(TraitObject);
 extern "C" void RustObject_destruct(TraitObject);
 
+/// "513 reserved for Qt Jambi's DeleteOnMainThread event"
+/// We are just re-using this event type for our purposes.
+///
+/// Source: https://github.com/qtjambi/qtjambi/blob/8ef99da63315945e6ab540cc31d66e5b021b69e4/src/cpp/qtjambi/qtjambidebugevent.cpp#L857
+#define QtJambi_EventType_DeleteOnMainThread 513
+
 template <typename Base>
 struct RustObject : Base {
     TraitObject rust_object;  // A QObjectPinned<XXX> where XXX is the base trait
@@ -71,8 +77,7 @@ struct RustObject : Base {
         return _id;
     }
     bool event(QEvent *event) override {
-        if (ptr_qobject && event->type() == 513) {
-            // "513 reserved for Qt Jambi's DeleteOnMainThread event"
+        if (ptr_qobject && event->type() == QtJambi_EventType_DeleteOnMainThread) {
             // This event is sent by rust when we are deleted.
             ptr_qobject = { nullptr, nullptr }; // so the destructor don't recurse
             delete this;

--- a/qmetaobject/qmetaobject_rust.hpp
+++ b/qmetaobject/qmetaobject_rust.hpp
@@ -47,7 +47,7 @@ extern "C" void RustObject_destruct(TraitObject);
 /// We are just re-using this event type for our purposes.
 ///
 /// Source: https://github.com/qtjambi/qtjambi/blob/8ef99da63315945e6ab540cc31d66e5b021b69e4/src/cpp/qtjambi/qtjambidebugevent.cpp#L857
-#define QtJambi_EventType_DeleteOnMainThread 513
+static constexpr int QtJambi_EventType_DeleteOnMainThread = 513;
 
 template <typename Base>
 struct RustObject : Base {

--- a/qmetaobject/qmetaobject_rust.hpp
+++ b/qmetaobject/qmetaobject_rust.hpp
@@ -27,7 +27,7 @@ union SignalCppRepresentation {
 
     SignalCppRepresentation() = default;
 
-    // Construct the object from an arbirary signal.
+    // Construct the object from an arbitrary signal.
     // (there is a double indirection in the reinterpret_cast to avoid -Wcast-function-type)
     template<typename R, typename Object, typename ...Args>
     SignalCppRepresentation(R (Object::*cpp_signal)(Args...))

--- a/qmetaobject/src/connections.rs
+++ b/qmetaobject/src/connections.rs
@@ -70,9 +70,9 @@ public:
 }}
 
 cpp_class!(
-/// Wrapper around Qt's QMetaObject::Connection
-///
-/// Can be used to detect if a connection is valid, and to disconnect a connection
+    /// Wrapper around Qt's QMetaObject::Connection
+    ///
+    /// Can be used to detect if a connection is valid, and to disconnect a connection.
     pub unsafe struct ConnectionHandle as "QMetaObject::Connection"
 );
 impl ConnectionHandle {
@@ -93,10 +93,10 @@ impl ConnectionHandle {
 }
 
 cpp_class!(
-/// Internal class that can be used to construct C++ signal.  Should only be used as an implementation
-/// details when writing bindings to Qt signals to construct a `CppSignal<...>`
-///
-/// It has the same size as a `void(QObject::*)()` and can be constructed from signals.
+    /// Internal class that can be used to construct C++ signal.  Should only be used as an implementation
+    /// details when writing bindings to Qt signals to construct a `CppSignal<...>`
+    ///
+    /// It has the same size as a `void(QObject::*)()` and can be constructed from signals.
     pub unsafe struct SignalCppRepresentation as "SignalCppRepresentation"
 );
 

--- a/qmetaobject/src/connections.rs
+++ b/qmetaobject/src/connections.rs
@@ -23,7 +23,7 @@ cpp! {{
 #include <QtCore/QObject>
 #include "qmetaobject_rust.hpp"
 
-//Access private function of QObject. Pretend to define QObjectPrivate.
+// Access private function of QObject. Pretend to define QObjectPrivate.
 // This rely on QObjectPrivate being a friend of QObject.
 class QObjectPrivate {
     public:
@@ -45,9 +45,10 @@ class RustSlotOject : public QtPrivate::QSlotObjectBase
             break;
         case Call: {
             auto slot = static_cast<RustSlotOject*>(this_)->slot;
-            rust!(RustSlotObject_call[slot : *mut dyn FnMut(*const *const c_void) as "TraitObject", a : *const *const c_void as "void**"] {
+            rust!(RustSlotObject_call[slot : *mut dyn FnMut(*const *const c_void) as "TraitObject",
+                                      a : *const *const c_void as "void**"] {
                    unsafe { (*slot)(a); }
-                });
+            });
             break;
         }
         case Compare: // not implemented
@@ -57,12 +58,16 @@ class RustSlotOject : public QtPrivate::QSlotObjectBase
     }
 public:
     explicit RustSlotOject(TraitObject slot) : QSlotObjectBase(&impl), slot(slot) {}
-    ~RustSlotOject() { rust!(RustSlotOject_destruct [slot : *mut dyn FnMut(*const *const c_void) as "TraitObject"] { unsafe { let _ = Box::from_raw(slot); } }); }
+    ~RustSlotOject() {
+        rust!(RustSlotOject_destruct [slot : *mut dyn FnMut(*const *const c_void) as "TraitObject"] {
+            let _ = unsafe { Box::from_raw(slot) };
+        });
+    }
     Q_DISABLE_COPY(RustSlotOject);
 };
 
 
-} }
+}}
 
 cpp_class!(
 /// Wrapper around Qt's QMetaObject::Connection
@@ -73,7 +78,7 @@ cpp_class!(
 impl ConnectionHandle {
     /// Disconnect this connection.
     ///
-    /// After this function is called, all ConnectionHandle refering to this connection will be invalided.
+    /// After this function is called, all ConnectionHandle referring to this connection will be invalided.
     /// Calling disconnect on an invalided connection does nothing.
     pub fn disconnect(&mut self) {
         unsafe { cpp!([self as "const QMetaObject::Connection*"] { QObject::disconnect(*self);  }) }

--- a/qmetaobject/src/future.rs
+++ b/qmetaobject/src/future.rs
@@ -74,7 +74,7 @@ cpp! {{
 /// Waking the waker will post an event to the Qt event loop which will poll the future
 /// from the event handler
 ///
-/// Note that this function returns immediatly. A Qt event loop need to be running
+/// Note that this function returns immediately. A Qt event loop need to be running
 /// on the current thread so the future can be executed. (It is Ok if the Qt event
 /// loop hasn't started yet when this function is called)
 pub fn execute_async(f: impl Future<Output = ()> + 'static) {

--- a/qmetaobject/src/lib.rs
+++ b/qmetaobject/src/lib.rs
@@ -809,8 +809,9 @@ fn add_to_hash(hash: *mut c_void, key: i32, value: QByteArray) {
 pub const USER_ROLE: i32 = 0x0100;
 
 cpp_class!(
-/// Wrapper for Qt's QMessageLogContext
-pub unsafe struct QMessageLogContext as "QMessageLogContext");
+    /// Wrapper for Qt's QMessageLogContext
+    pub unsafe struct QMessageLogContext as "QMessageLogContext"
+);
 impl QMessageLogContext {
     // Return QMessageLogContext::line
     pub fn line(&self) -> i32 {

--- a/qmetaobject/src/lib.rs
+++ b/qmetaobject/src/lib.rs
@@ -191,7 +191,7 @@ impl Drop for QObjectCppWrapper {
         unsafe {
             cpp!([ptr as "QObject*"] {
                 // The event 513 is caught by RustObject and deletes the object.
-                QEvent e(QEvent::Type(513));
+                QEvent e(QEvent::Type(QtJambi_EventType_DeleteOnMainThread));
                 if (ptr)
                     ptr->event(&e);
             })

--- a/qmetaobject/src/lib.rs
+++ b/qmetaobject/src/lib.rs
@@ -191,7 +191,7 @@ impl Drop for QObjectCppWrapper {
         unsafe {
             cpp!([ptr as "QObject*"] {
                 // The event 513 is caught by RustObject and deletes the object.
-                QEvent e(QEvent::Type(QtJambi_EventType_DeleteOnMainThread));
+                QEvent e = QEvent(QEvent::Type(QtJambi_EventType_DeleteOnMainThread));
                 if (ptr)
                     ptr->event(&e);
             })

--- a/qmetaobject/src/lib.rs
+++ b/qmetaobject/src/lib.rs
@@ -30,7 +30,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     struct Greeter {
         // Specify the base class with the qt_base_class macro
         base : qt_base_class!(trait QObject),
-        // Decalare `name` as a property usable from Qt
+        // Declare `name` as a property usable from Qt
         name : qt_property!(QString; NOTIFY name_changed),
         // Declare a signal
         name_changed : qt_signal!(),
@@ -125,7 +125,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 });
             });
             std::thread::spawn(move || {
-                // do stuff asynchroniously ...
+                // do stuff asynchronously ...
                 let r = QString::from("Hello ".to_owned() + &name);
                 set_value(r);
             }).join();
@@ -190,7 +190,7 @@ impl Drop for QObjectCppWrapper {
         let ptr = self.ptr;
         unsafe {
             cpp!([ptr as "QObject*"] {
-                // The event 513 is catched by RustObject and deletes the object.
+                // The event 513 is caught by RustObject and deletes the object.
                 QEvent e(QEvent::Type(513));
                 if (ptr)
                     ptr->event(&e);
@@ -279,7 +279,7 @@ pub trait QObject {
     fn get_object_description() -> &'static QObjectDescription where Self:Sized {
         unsafe { &*cpp!([]-> *const QObjectDescription as "RustObjectDescription const*" {
             return rustObjectDescription<RustObject<QObject>>();
-        } ) }
+        })}
     }
 }
 impl dyn QObject {
@@ -295,7 +295,6 @@ impl dyn QObject {
             return QVariant::fromValue(self_);
         }}
     }
-
 
     /// See Qt documentation for QObject::destroyed
     pub fn destroyed_signal() -> CppSignal<fn()> {
@@ -334,7 +333,7 @@ impl<T: QObject + ?Sized> QPointer<T> {
         })
     }
 
-    /// Returns a reference to the opbject, or None if it was deleted
+    /// Returns a reference to the `QObject`, or None if it was deleted
     pub fn as_ref(&self) -> Option<&T> {
         let x = self.cpp_ptr();
         if x.is_null() {
@@ -351,7 +350,7 @@ impl<T: QObject + ?Sized> QPointer<T> {
     }
 }
 impl<T: QObject> QPointer<T> {
-    /// Returns a pinned reference to the opbject, or None if it was deleted
+    /// Returns a pinned reference to the QObject, or None if it was deleted
     pub fn as_pinned(&self) -> Option<QObjectPinned<T>> {
         let x = self.cpp_ptr();
         if x.is_null() {
@@ -385,7 +384,7 @@ impl<T: QObject + ?Sized> Clone for QPointer<T> {
     }
 }
 
-/// Same as std::cell::RefMut,  but does not allow to move from
+/// Same as std::cell::RefMut, but does not allow to move from
 pub struct QObjectRefMut<'b, T: QObject + ?Sized + 'b> {
     old_value: *mut c_void,
     inner: std::cell::RefMut<'b, T>,
@@ -427,7 +426,7 @@ impl<'pin, T: QObject + ?Sized + 'pin> Copy for QObjectPinned<'pin, T> {}
 
 impl<'pin, T: QObject + ?Sized + 'pin> QObjectPinned<'pin, T> {
     /// Borrow the object
-    // FIXME: there are too many case for which we want re-entrency after borrowing
+    // FIXME: there are too many cases for which we want reentrance after borrowing
     //pub fn borrow(&self) -> std::cell::Ref<T> { self.0.borrow() }
     #[cfg_attr(feature = "cargo-clippy", allow(clippy::should_implement_trait))]
     pub fn borrow(&self) -> &T {
@@ -765,7 +764,7 @@ pub fn queued_callback<T: Send, F: FnMut(T) + 'static>(
     unsafe impl<T> Send for UnsafeSendFn<T> {}
     unsafe impl<T> Sync for UnsafeSendFn<T> {}
     // put func in an arc because we need to keep it alive as long as the internal Box<FnMut> is
-    // alive. (And we can't just move it there because the returned closure can be called serveral
+    // alive. (And we can't just move it there because the returned closure can be called several
     // times.
     let func = std::sync::Arc::new(UnsafeSendFn(RefCell::new(func)));
 

--- a/qmetaobject/src/qmetatype.rs
+++ b/qmetaobject/src/qmetatype.rs
@@ -283,7 +283,7 @@ qdeclare_builtin_metatype! {usize  => 5} // That's QMetaType::ULongLong
 /// Don't implement this trait, implement the QMetaType trait.
 pub trait PropertyType {
     fn register_type(name: &std::ffi::CStr) -> i32;
-    // Note: this is &mut self becauser of the lazy initialization of the QObject* for the QObject impl
+    // Note: this is &mut self because of the lazy initialization of the QObject* for the QObject impl
     unsafe fn pass_to_qt(&mut self, a: *mut c_void);
     unsafe fn read_from_qt(a: *const c_void) -> Self;
 }

--- a/qmetaobject/src/qmetatype.rs
+++ b/qmetaobject/src/qmetatype.rs
@@ -292,6 +292,10 @@ impl<T: QMetaType> PropertyType for T
 where
     T: QMetaType,
 {
+    fn register_type(name: &std::ffi::CStr) -> i32 {
+        <T as QMetaType>::register(Some(name))
+    }
+
     unsafe fn pass_to_qt(&mut self, a: *mut c_void) {
         let r = a as *mut Self;
         if !r.is_null() {
@@ -302,10 +306,6 @@ where
     unsafe fn read_from_qt(a: *const c_void) -> Self {
         let r = a as *const Self;
         (*r).clone()
-    }
-
-    fn register_type(name: &std::ffi::CStr) -> i32 {
-        <T as QMetaType>::register(Some(name))
     }
 }
 

--- a/qmetaobject/src/qrc.rs
+++ b/qmetaobject/src/qrc.rs
@@ -24,7 +24,7 @@ Q_CORE_EXPORT bool qRegisterResourceData(int, const unsigned char *,
 /// Macro to embed files and made them available to the Qt resource system
 ///
 /// ```ignore
-/// qrc!(my_ressource,
+/// qrc!(my_resource,
 ///     "qml" {
 ///         "main.qml",
 ///         "Foo.qml" as "foo/Foo.qml",

--- a/qmetaobject/src/qtdeclarative.rs
+++ b/qmetaobject/src/qtdeclarative.rs
@@ -33,7 +33,7 @@ cpp! {{
         SingleApplicationGuard() {
             rust!(Rust_QmlEngineHolder_ctor[] {
                 HAS_ENGINE.compare_exchange(false, true, std::sync::atomic::Ordering::SeqCst, std::sync::atomic::Ordering::SeqCst)
-                        .expect("There can only be one QmlEngine in the process");
+                    .expect("There can only be one QmlEngine in the process");
             });
         }
         ~SingleApplicationGuard() {
@@ -183,7 +183,7 @@ impl QmlEngine {
         }
     }
 
-    /// Give a QObject to the engine by wraping it in a QJSValue
+    /// Give a QObject to the engine by wrapping it in a QJSValue
     ///
     /// This will create the C++ object.
     /// Panic if the C++ object was already created.

--- a/qmetaobject/src/qtdeclarative.rs
+++ b/qmetaobject/src/qtdeclarative.rs
@@ -458,10 +458,13 @@ pub trait QSingletonInit {
 /// After construction of the corresponding C++ object the `QSingletonInit::init()` function 
 /// will be called.
 ///
-/// Refer to the Qt documentation for qmlRegisterSingletonType.
+/// Refer to the Qt documentation for [qmlRegisterSingletonType][].
 ///
 /// # Panics
+///
 /// The process will be aborted when the default or init functions panic.
+///
+/// [qmlRegisterSingletonType]: https://doc.qt.io/qt-5/qqmlengine.html#qmlRegisterSingletonType-3
 pub fn qml_register_singleton_type<T: QObject + QSingletonInit + Sized + Default>(
     uri: &std::ffi::CStr,
     version_major: u32,
@@ -534,8 +537,14 @@ pub fn qml_register_singleton_type<T: QObject + QSingletonInit + Sized + Default
 ///
 /// The object is shared between all instances of `QmlEngine`.
 ///
-/// Refer to the Qt documentation for qmlRegisterSingletonInstance.
-/// Only avaiable in Qt 5.14 or above.
+/// Refer to the Qt documentation for [qmlRegisterSingletonInstance][] (not documented at the time of writing).
+///
+/// # Availability
+///
+/// Only available in Qt 5.14 or above.
+///
+/// [qmlRegisterSingletonInstance]: https://doc.qt.io/qt-5/qtqml-cppintegration-overview.html
+// XXX: replace link with real documentation, when it will be generated.
 #[cfg(qt_5_14)]
 pub fn qml_register_singleton_instance<T: QObject + Sized + Default>(
     uri: &std::ffi::CStr,
@@ -562,9 +571,11 @@ pub fn qml_register_singleton_instance<T: QObject + Sized + Default>(
     }
 }
 
-/// Register the given enum as a QML type
+/// Register the given enum as a QML type.
 ///
-/// Refer to the Qt documentation for qmlRegisterUncreatableMetaObject.
+/// Refer to the Qt documentation for [qmlRegisterUncreatableMetaObject][].
+///
+/// [qmlRegisterUncreatableMetaObject]: https://doc.qt.io/qt-5/qqmlengine.html#qmlRegisterUncreatableMetaObject
 pub fn qml_register_enum<T: QEnum>(
     uri: &std::ffi::CStr,
     version_major: u32,

--- a/qmetaobject/src/qttypes.rs
+++ b/qmetaobject/src/qttypes.rs
@@ -611,7 +611,7 @@ impl IndexMut<usize> for QVariantList {
     }
 }
 
-/// Iternal class used to iterate over a QVariantList
+/// Internal class used to iterate over a QVariantList
 pub struct QVariantListIterator<'a> {
     list: &'a QVariantList,
     index: usize,
@@ -683,7 +683,7 @@ mod tests {
     }
 
     #[test]
-    fn test_qstring_and_qbytearrazy() {
+    fn test_qstring_and_qbytearray() {
         let qba1: QByteArray = (b"hello" as &[u8]).into();
         let qba2: QByteArray = "hello".into();
         let s: String = "hello".into();
@@ -838,7 +838,6 @@ impl QColor {
             return QColor::fromRgbF(r, g, b, a);
         })
     }
-
     /// Returns the individual component as floating point.
     /// Refer to the Qt documentation of QColor::getRgbF.
     pub fn get_rgba(&self) -> (qreal, qreal, qreal, qreal) {

--- a/qmetaobject/src/qttypes.rs
+++ b/qmetaobject/src/qttypes.rs
@@ -119,8 +119,8 @@ impl QDate {
     /// Returns the year, month and day components.
     /// Refer to the Qt documentation for QDate::getDate.
     pub fn get_y_m_d(&self) -> (i32, i32, i32) {
-        let res = (0, 0, 0);
-        let (ref y, ref m, ref d) = res;
+        let mut res = (0, 0, 0);
+        let (ref mut y, ref mut m, ref mut d) = res;
         cpp!(unsafe [self as "const QDate*", y as "int*", m as "int*", d as "int*"] {
             return self->getDate(y, m, d);
         });

--- a/qmetaobject/src/qttypes.rs
+++ b/qmetaobject/src/qttypes.rs
@@ -15,6 +15,7 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FO
 OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
+//! Various bindings and wrappers for Qt classes, enums, member/static methods and functions.
 extern crate std;
 use std::convert::From;
 use std::fmt::Display;
@@ -27,7 +28,9 @@ use std::str::Utf8Error;
 use chrono::prelude::*;
 
 cpp_class!(
-    /// Wrapper around Qt's QByteArray
+    /// Wrapper around [`QByteArray`][class] class.
+    ///
+    /// [class]: https://doc.qt.io/qt-5/qbytearray.html
     #[derive(PartialEq, PartialOrd, Eq, Ord)]
     pub unsafe struct QByteArray as "QByteArray"
 );
@@ -47,7 +50,7 @@ impl QByteArray {
     }
 }
 impl<'a> From<&'a [u8]> for QByteArray {
-    /// Constructs a QByteArray from a slice. (Copy the slice.)
+    /// Constructs a `QByteArray` from a slice. (Copy the slice.)
     fn from(s: &'a [u8]) -> QByteArray {
         let len = s.len();
         let ptr = s.as_ptr();
@@ -57,20 +60,19 @@ impl<'a> From<&'a [u8]> for QByteArray {
     }
 }
 impl<'a> From<&'a str> for QByteArray {
-    /// Constructs a QByteArray from a &str. (Copy the string.)
+    /// Constructs a `QByteArray` from a `&str`. (Copy the string.)
     fn from(s: &'a str) -> QByteArray {
         s.as_bytes().into()
     }
 }
-
 impl From<String> for QByteArray {
-    /// Constructs a QByteArray from a String. (Copy the string.)
+    /// Constructs a `QByteArray` from a `String`. (Copy the string.)
     fn from(s: String) -> QByteArray {
         QByteArray::from(&*s)
     }
 }
 impl From<QString> for QByteArray {
-    /// Converts a QString to a QByteArray
+    /// Converts a `QString` to a `QByteArray`
     fn from(s: QString) -> QByteArray {
         cpp!(unsafe [s as "QString"] -> QByteArray as "QByteArray" {
             return std::move(s).toUtf8();
@@ -78,7 +80,7 @@ impl From<QString> for QByteArray {
     }
 }
 impl Display for QByteArray {
-    /// Prints the contents of the QByteArray if it contains UTF-8,  nothing otherwise
+    /// Prints the contents of the `QByteArray` if it contains UTF-8, do nothing otherwise.
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         unsafe {
             let c_ptr = cpp!([self as "const QByteArray*"] -> *const c_char as "const char*" {
@@ -93,29 +95,36 @@ impl Display for QByteArray {
     }
 }
 impl std::fmt::Debug for QByteArray {
-    /// Prints the contents of the QByteArray if it contains UTF-8,  nothing otherwise
+    /// Prints the contents of the `QByteArray` if it contains UTF-8,  nothing otherwise
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self)
     }
 }
 
 cpp_class!(
-    /// Wrapper around Qt's QDate class
+    /// Wrapper around [`QDate`][class] class.
+    ///
+    /// [class]: https://doc.qt.io/qt-5/qdate.html
     #[derive(PartialEq, PartialOrd, Eq, Ord)]
     pub unsafe struct QDate as "QDate"
 );
-
 impl QDate {
-    /// Constructs a QDate from the year, month and date.
-    /// Refer to the Qt documentation for the QDate constructor.
+    /// Wrapper around [`QDate(int y, int m, int d)`][ctor] constructor.
+    ///
+    /// [ctor]: https://doc.qt.io/qt-5/qdate.html#QDate-2
     pub fn from_y_m_d(y: i32, m: i32, d: i32) -> Self {
         cpp!(unsafe [y as "int", m as "int", d as "int"] -> QDate as "QDate" {
             return QDate(y, m, d);
         })
     }
 
-    /// Returns the year, month and day components.
-    /// Refer to the Qt documentation for QDate::getDate.
+    /// Wrapper around [`QDate::getDate(int *year, int *month, int *day)`][method] method.
+    ///
+    /// # Wrapper-specific
+    ///
+    /// Returns the year, month and day components as a tuple, instead of mutable references.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qdate.html#getDate
     pub fn get_y_m_d(&self) -> (i32, i32, i32) {
         let mut res = (0, 0, 0);
         let (ref mut y, ref mut m, ref mut d) = res;
@@ -125,21 +134,21 @@ impl QDate {
         res
     }
 
-    /// Refer to the Qt documentation for QDate::isValid.
+    /// Wrapper around [`QDate::isValid()`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qdate.html#isValid
     pub fn is_valid(&self) -> bool {
         cpp!(unsafe [self as "const QDate*"] -> bool as "bool" {
             return self->isValid();
         })
     }
 }
-
 #[cfg(feature = "chrono_qdatetime")]
 impl From<NaiveDate> for QDate {
     fn from(a: NaiveDate) -> QDate {
         QDate::from_y_m_d(a.year() as i32, a.month() as i32, a.day() as i32)
     }
 }
-
 #[cfg(feature = "chrono_qdatetime")]
 impl Into<NaiveDate> for QDate {
     fn into(self) -> NaiveDate {
@@ -176,14 +185,20 @@ fn test_qdate_chrono() {
 }
 
 cpp_class!(
-    /// Wrapper around Qt's QTime class
+    /// Wrapper around [`QTime`][class] class.
+    ///
+    /// [class]: https://doc.qt.io/qt-5/qtime.html
     #[derive(PartialEq, PartialOrd, Eq, Ord)]
     pub unsafe struct QTime as "QTime"
 );
-
 impl QTime {
-    /// Constructs a QTime from hours and minutes, and optionally seconds and milliseconds.
-    /// Refer to the Qt documentation for the QTime constructor.
+    /// Wrapper around [`QTime(int h, int m, int s = 0, int ms = 0)`][ctor] constructor.
+    ///
+    /// # Wrapper-specific
+    ///
+    /// Default arguments converted to `Option`s.
+    ///
+    /// [ctor]: https://doc.qt.io/qt-5/qtime.html#QTime-2
     pub fn from_h_m_s_ms(h: i32, m: i32, s: Option<i32>, ms: Option<i32>) -> Self {
         let s = s.unwrap_or(0);
         let ms = ms.unwrap_or(0);
@@ -193,28 +208,36 @@ impl QTime {
         })
     }
 
-    /// Refer to the Qt documentation for QTime::hour.
+    /// Wrapper around [`QTime::hour()`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qtime.html#hour
     pub fn get_hour(&self) -> i32 {
         cpp!(unsafe [self as "const QTime*"] -> i32 as "int" {
             return self->hour();
         })
     }
 
-    /// Refer to the Qt documentation for QTime::minute.
+    /// Wrapper around [`QTime::minute()`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qtime.html#minute
     pub fn get_minute(&self) -> i32 {
         cpp!(unsafe [self as "const QTime*"] -> i32 as "int" {
             return self->minute();
         })
     }
 
-    /// Refer to the Qt documentation for QTime::second.
+    /// Wrapper around [`QTime::second()`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qtime.html#second
     pub fn get_second(&self) -> i32 {
         cpp!(unsafe [self as "const QTime*"] -> i32 as "int" {
             return self->second();
         })
     }
 
-    /// Refer to the Qt documentation for QTime::msec.
+    /// Wrapper around [`QTime::msec()`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qtime.html#msec
     pub fn get_msec(&self) -> i32 {
         cpp!(unsafe [self as "const QTime*"] -> i32 as "int" {
             return self->msec();
@@ -231,7 +254,9 @@ impl QTime {
         )
     }
 
-    /// Refer to the Qt documentation for QTime::isValid.
+    /// Wrapper around [`QTime::isValid()`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qtime.html#isValid
     pub fn is_valid(&self) -> bool {
         cpp!(unsafe [self as "const QTime*"] -> bool as "bool" {
             return self->isValid();
@@ -287,40 +312,47 @@ fn test_qtime_is_valid() {
 }
 
 cpp_class!(
-    /// Wrapper around Qt's QDateTime class
+    /// Wrapper around [`QDateTime`][class] class.
+    ///
+    /// [class]: https://doc.qt.io/qt-5/qdatetime.html
     #[derive(PartialEq, PartialOrd, Eq, Ord)]
     pub unsafe struct QDateTime as "QDateTime"
 );
-
 impl QDateTime {
-    /// Constructs a QDateTime from a QDate.
-    /// Refer to the documentation for QDateTime's constructor using QDate.
+    /// Wrapper around [`QDateTime(const QDateTime &other)`][ctor] constructor.
+    ///
+    /// [ctor]: https://doc.qt.io/qt-5/qdatetime.html#QDateTime-1
     pub fn from_date(date: QDate) -> Self {
         cpp!(unsafe [date as "QDate"] -> QDateTime as "QDateTime" {
             return QDateTime(date);
         })
     }
 
-    /// Constructs a QDateTime from a QDate and a QTime, using the current system timezone.
+    /// Wrapper around [`QDateTime(const QDate &date, const QTime &time, Qt::TimeSpec spec = Qt::LocalTime)`][ctor] constructor.
     ///
-    /// Equivalent to the C++ code `QDateTime(date, time)`.
-    /// Refer to the documentation for QDateTime's constructor using QDate, QTime and Qt::TimeSpec.
+    /// # Wrapper-specific
+    ///
+    /// `spec` is left as it is, thus it is always `Qt::LocalTime`.
+    ///
+    /// [ctor]: https://doc.qt.io/qt-5/qdatetime.html#QDateTime-2
     pub fn from_date_time_local_timezone(date: QDate, time: QTime) -> Self {
         cpp!(unsafe [date as "QDate", time as "QTime"] -> QDateTime as "QDateTime" {
             return QDateTime(date, time);
         })
     }
 
-    /// Gets the date component from a QDateTime.
-    /// Refer to the documentation for QDateTime::date.
+    /// Wrapper around [`QDateTime::date()`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qdatetime.html#date
     pub fn get_date(&self) -> QDate {
         cpp!(unsafe [self as "const QDateTime*"] -> QDate as "QDate" {
             return self->date();
         })
     }
 
-    /// Gets the time component from a QDateTime.
-    /// Refer to the documentation for QDateTime::time.
+    /// Wrapper around [`QDateTime::time()`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qdatetime.html#time
     pub fn get_time(&self) -> QTime {
         cpp!(unsafe [self as "const QDateTime*"] -> QTime as "QTime" {
             return self->time();
@@ -332,7 +364,9 @@ impl QDateTime {
         (self.get_date(), self.get_time())
     }
 
-    /// Refer to the Qt documentation for QDateTime::isValid.
+    /// Wrapper around [`QDateTime::isValid()`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qdatetime.html#isValid
     pub fn is_valid(&self) -> bool {
         cpp!(unsafe [self as "const QDateTime*"] -> bool as "bool" {
             return self->isValid();
@@ -396,15 +430,16 @@ fn test_qdatetime_is_valid() {
 }
 
 cpp_class!(
-    /// Wrapper around Qt's QUrl class
+    /// Wrapper around [`QUrl`][class] class.
+    ///
+    /// [class]: https://doc.qt.io/qt-5/qurl.html
     #[derive(PartialEq, PartialOrd, Eq, Ord)]
     pub unsafe struct QUrl as "QUrl"
 );
-
 impl QUrl {
-    /// Returns a valid URL from a user supplied qstring if one can be deducted.
-    /// In the case that is not possible, an invalid QUrl is returned.
-    /// 
+    /// Wrapper around [`QUrl::fromUserInput(const QString &userInput)`][method] static method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qurl.html#fromUserInput
     pub fn from_user_input(user_input: QString) -> QUrl {
         cpp!(unsafe [user_input as "QString"] -> QUrl as "QUrl" {
             return QUrl::fromUserInput(user_input);
@@ -420,12 +455,14 @@ impl From<QString> for QUrl {
 }
 
 cpp_class!(
-    /// Wrapper around Qt's QString class
+    /// Wrapper around [`QString`][class] class.
+    ///
+    /// [class]: https://doc.qt.io/qt-5/qstring.html
     #[derive(PartialEq, PartialOrd, Eq, Ord)]
     pub unsafe struct QString as "QString"
 );
 impl QString {
-    /// Return a slice containing the UTF-16 data
+    /// Return a slice containing the UTF-16 data.
     pub fn to_slice(&self) -> &[u16] {
         unsafe {
             let mut size: usize = 0;
@@ -438,6 +475,13 @@ impl QString {
     }
 }
 impl From<QUrl> for QString {
+    /// Wrapper around [`QUrl::toString(QUrl::FormattingOptions=...)`][method] method.
+    ///
+    /// # Wrapper-specific
+    ///
+    /// Formatting options are left at defaults.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qurl.html#toString
     fn from(qurl: QUrl) -> QString {
         cpp!(unsafe [qurl as "QUrl"] -> QString as "QString" {
             return qurl.toString();
@@ -445,7 +489,7 @@ impl From<QUrl> for QString {
     }
 }
 impl<'a> From<&'a str> for QString {
-    /// Copy the data from a &str
+    /// Copy the data from a `&str`.
     fn from(s: &'a str) -> QString {
         let len = s.len();
         let ptr = s.as_ptr();
@@ -476,17 +520,25 @@ impl std::fmt::Debug for QString {
 }
 
 cpp_class!(
-    /// Wrapper around a QVariant
+    /// Wrapper around [`QVariant`][class] class.
+    ///
+    /// [class]: https://doc.qt.io/qt-5/qvariant.html
     #[derive(PartialEq)]
     pub unsafe struct QVariant as "QVariant"
 );
 impl QVariant {
+    /// Wrapper around [`toByteArray()`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qvariant.html#toByteArray
     pub fn to_qbytearray(&self) -> QByteArray {
         cpp!(unsafe [self as "const QVariant*"] -> QByteArray as "QByteArray" {
             return self->toByteArray();
         })
     }
 
+    /// Wrapper around [`toBool()`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qvariant.html#toBool
     pub fn to_bool(&self) -> bool {
         cpp!(unsafe [self as "const QVariant*"] -> bool as "bool" {
             return self->toBool();
@@ -496,6 +548,9 @@ impl QVariant {
     // FIXME: do more wrappers
 }
 impl From<QString> for QVariant {
+    /// Wrapper around [`QVariant(const QString &)`][ctor] constructor.
+    ///
+    /// [ctor]: https://doc.qt.io/qt-5/qvariant.html#QVariant-14
     fn from(a: QString) -> QVariant {
         cpp!(unsafe [a as "QString"] -> QVariant as "QVariant" {
             return QVariant(a);
@@ -503,6 +558,9 @@ impl From<QString> for QVariant {
     }
 }
 impl From<QByteArray> for QVariant {
+    /// Wrapper around [`QVariant(const QByteArray &)`][ctor] constructor.
+    ///
+    /// [ctor]: https://doc.qt.io/qt-5/qvariant.html#QVariant-12
     fn from(a: QByteArray) -> QVariant {
         cpp!(unsafe [a as "QByteArray"] -> QVariant as "QVariant" {
             return QVariant(a);
@@ -510,6 +568,9 @@ impl From<QByteArray> for QVariant {
     }
 }
 impl From<QDate> for QVariant {
+    /// Wrapper around [`QVariant(const QDate &)`][ctor] constructor.
+    ///
+    /// [ctor]: https://doc.qt.io/qt-5/qvariant.html#QVariant-18
     fn from(a: QDate) -> QVariant {
         cpp!(unsafe [a as "QDate"] -> QVariant as "QVariant" {
             return QVariant(a);
@@ -517,6 +578,9 @@ impl From<QDate> for QVariant {
     }
 }
 impl From<QTime> for QVariant {
+    /// Wrapper around [`QVariant(const QTime &)`][ctor] constructor.
+    ///
+    /// [ctor]: https://doc.qt.io/qt-5/qvariant.html#QVariant-19
     fn from(a: QTime) -> QVariant {
         cpp!(unsafe [a as "QTime"] -> QVariant as "QVariant" {
             return QVariant(a);
@@ -524,6 +588,9 @@ impl From<QTime> for QVariant {
     }
 }
 impl From<QDateTime> for QVariant {
+    /// Wrapper around [`QVariant(const QDateTime &)`][ctor] constructor.
+    ///
+    /// [ctor]: https://doc.qt.io/qt-5/qvariant.html#QVariant-20
     fn from(a: QDateTime) -> QVariant {
         cpp!(unsafe [a as "QDateTime"] -> QVariant as "QVariant" {
             return QVariant(a);
@@ -531,6 +598,9 @@ impl From<QDateTime> for QVariant {
     }
 }
 impl From<QUrl> for QVariant {
+    /// Wrapper around [`QVariant(const QUrl &)`][ctor] constructor.
+    ///
+    /// [ctor]: https://doc.qt.io/qt-5/qvariant.html#QVariant-35
     fn from(a: QUrl) -> QVariant {
         cpp!(unsafe [a as "QUrl"] -> QVariant as "QVariant" {
             return QVariant(a);
@@ -538,6 +608,9 @@ impl From<QUrl> for QVariant {
     }
 }
 impl From<QVariantList> for QVariant {
+    /// Wrapper around [`QVariant(const QVariantList &)`][ctor] constructor.
+    ///
+    /// [ctor]: https://doc.qt.io/qt-5/qvariant.html#QVariant-21
     fn from(a: QVariantList) -> QVariant {
         cpp!(unsafe [a as "QVariantList"] -> QVariant as "QVariant" {
             return QVariant(a);
@@ -545,6 +618,9 @@ impl From<QVariantList> for QVariant {
     }
 }
 impl From<i32> for QVariant {
+    /// Wrapper around [`QVariant(int)`][ctor] constructor.
+    ///
+    /// [ctor]: https://doc.qt.io/qt-5/qvariant.html#QVariant-4
     fn from(a: i32) -> QVariant {
         cpp!(unsafe [a as "int"] -> QVariant as "QVariant" {
             return QVariant(a);
@@ -552,6 +628,9 @@ impl From<i32> for QVariant {
     }
 }
 impl From<u32> for QVariant {
+    /// Wrapper around [`QVariant(uint)`][ctor] constructor.
+    ///
+    /// [ctor]: https://doc.qt.io/qt-5/qvariant.html#QVariant-5
     fn from(a: u32) -> QVariant {
         cpp!(unsafe [a as "uint"] -> QVariant as "QVariant" {
             return QVariant(a);
@@ -559,6 +638,9 @@ impl From<u32> for QVariant {
     }
 }
 impl From<f32> for QVariant {
+    /// Wrapper around [`QVariant(float)`][ctor] constructor.
+    ///
+    /// [ctor]: https://doc.qt.io/qt-5/qvariant.html#QVariant-10
     fn from(a: f32) -> QVariant {
         cpp!(unsafe [a as "float"] -> QVariant as "QVariant" {
             return QVariant(a);
@@ -566,6 +648,9 @@ impl From<f32> for QVariant {
     }
 }
 impl From<f64> for QVariant {
+    /// Wrapper around [`QVariant(double)`][ctor] constructor.
+    ///
+    /// [ctor]: https://doc.qt.io/qt-5/qvariant.html#QVariant-9
     fn from(a: f64) -> QVariant {
         cpp!(unsafe [a as "double"] -> QVariant as "QVariant" {
             return QVariant(a);
@@ -573,6 +658,9 @@ impl From<f64> for QVariant {
     }
 }
 impl From<bool> for QVariant {
+    /// Wrapper around [`QVariant(bool)`][ctor] constructor.
+    ///
+    /// [ctor]: https://doc.qt.io/qt-5/qvariant.html#QVariant-8
     fn from(a: bool) -> QVariant {
         cpp!(unsafe [a as "bool"] -> QVariant as "QVariant" {
             return QVariant(a);
@@ -589,37 +677,63 @@ where
 }
 
 cpp_class!(
-    /// Wrapper around QVariantList
+    /// Wrapper around [`QVariantList`][type] typedef.
+    ///
+    /// [type]: https://doc.qt.io/qt-5/qvariant.html#QVariantList-typedef
     pub unsafe struct QVariantList as "QVariantList"
 );
 impl QVariantList {
+    /// Wrapper around [`append(const T &)`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qlist.html#append
     pub fn push(&mut self, value: QVariant) {
         cpp!(unsafe [self as "QVariantList*", value as "QVariant"] {
             self->append(std::move(value));
         })
     }
+
+    /// Wrapper around [`insert(int, const QVariant &)`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qlist.html#insert
     pub fn insert(&mut self, index: usize, element: QVariant) {
         cpp!(unsafe [self as "QVariantList*", index as "size_t", element as "QVariant"] {
             self->insert(index, std::move(element));
         })
     }
+
+    /// Wrapper around [`takeAt(int)`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qlist.html#takeAt
     pub fn remove(&mut self, index: usize) -> QVariant {
         cpp!(unsafe [self as "QVariantList*", index as "size_t"] -> QVariant as "QVariant" {
             return self->takeAt(index);
         })
     }
+
+    /// Wrapper around [`size()`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qlist.html#size
     pub fn len(&self) -> usize {
         cpp!(unsafe [self as "QVariantList*"] -> usize as "size_t" {
             return self->size();
         })
     }
+
+    /// Wrapper around [`isEmpty()`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qlist.html#isEmpty
     pub fn is_empty(&self) -> bool {
-        self.len() == 0
+        cpp!(unsafe [self as "QVariantList*"] -> bool as "bool" {
+            return self->isEmpty();
+        })
     }
 }
-
 impl Index<usize> for QVariantList {
     type Output = QVariant;
+
+    /// Wrapper around [`at(int)`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qlist.html#at
     fn index(&self, index: usize) -> &QVariant {
         assert!(index < self.len());
         unsafe { &*cpp!([self as "QVariantList*", index as "size_t"] -> *const QVariant as "const QVariant*" {
@@ -628,6 +742,9 @@ impl Index<usize> for QVariantList {
     }
 }
 impl IndexMut<usize> for QVariantList {
+    /// Wrapper around [`operator[](int)`][method] operator method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qlist.html#operator-5b-5d
     fn index_mut(&mut self, index: usize) -> &mut QVariant {
         assert!(index < self.len());
         unsafe { &mut *cpp!([self as "QVariantList*", index as "size_t"] -> *mut QVariant as "QVariant*" {
@@ -636,7 +753,9 @@ impl IndexMut<usize> for QVariantList {
     }
 }
 
-/// Internal class used to iterate over a QVariantList
+/// Internal class used to iterate over a [`QVariantList`][]
+///
+/// [`QVariantList`]: ./struct.QVariantList.html
 pub struct QVariantListIterator<'a> {
     list: &'a QVariantList,
     index: usize,
@@ -754,30 +873,51 @@ mod tests {
 }
 
 cpp_class!(
-    /// Wrapper around Qt's QModelIndex
+    /// Wrapper around [`QModelIndex`][class] class.
+    ///
+    /// [class]: https://doc.qt.io/qt-5/qmodelindex.html
     #[derive(PartialEq, Eq)]
     pub unsafe struct QModelIndex as "QModelIndex"
 );
 impl QModelIndex {
-    /// Return the QModelIndex::internalId
+    /// Wrapper around [`internalId()`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qmodelindex.html#internalId
     pub fn id(&self) -> usize {
         cpp!(unsafe [self as "const QModelIndex*"] -> usize as "uintptr_t" { return self->internalId(); })
     }
+
+    /// Wrapper around [`column()`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qmodelindex.html#column
     pub fn column(&self) -> i32 {
         cpp!(unsafe [self as "const QModelIndex*"] -> i32 as "int" { return self->column(); })
     }
+
+    /// Wrapper around [`row()`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qmodelindex.html#row
     pub fn row(&self) -> i32 {
         cpp!(unsafe [self as "const QModelIndex*"] -> i32 as "int" { return self->row(); })
     }
+
+    /// Wrapper around [`isValid()`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qmodelindex.html#isValid
     pub fn is_valid(&self) -> bool {
         cpp!(unsafe [self as "const QModelIndex*"] -> bool as "bool" { return self->isValid(); })
     }
 }
 
+/// Bindings for [`qreal`][type] typedef.
+///
+/// [type]: https://doc.qt.io/qt-5/qtglobal.html#qreal-typedef
 #[allow(non_camel_case_types)]
-type qreal = f64;
+pub type qreal = f64;
 
-/// Wrapper around QRectF
+/// Bindings for [`QRectF`][class] class.
+///
+/// [class]: https://doc.qt.io/qt-5/qrectf.html
 #[repr(C)]
 #[derive(Default, Clone, Copy, PartialEq, Debug)]
 pub struct QRectF {
@@ -786,13 +926,17 @@ pub struct QRectF {
     pub width: qreal,
     pub height: qreal,
 }
-
 impl QRectF {
+    /// Wrapper around [`contains(const QPointF &)`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qrectf.html#contains
     pub fn contains(&self, pos: QPointF) -> bool {
         cpp!(unsafe [self as "const QRectF*", pos as "QPointF"] -> bool as "bool" {
             return self->contains(pos);
         })
     }
+
+    // XXX: shouldn't it be a wrapper for cpp call?
     pub fn top_left(&self) -> QPointF {
         QPointF {
             x: self.x,
@@ -801,7 +945,9 @@ impl QRectF {
     }
 }
 
-/// Wrapper around QPointF
+/// Bindings for [`QPointF`][class] class.
+///
+/// [class]: https://doc.qt.io/qt-5/qpointf.html
 #[repr(C)]
 #[derive(Default, Clone, Copy, PartialEq, Debug)]
 pub struct QPointF {
@@ -810,6 +956,9 @@ pub struct QPointF {
 }
 impl std::ops::Add for QPointF {
     type Output = QPointF;
+    /// Wrapper around [`operator+(const QPointF &, const QPointF &)`][func] function.
+    ///
+    /// [func]: https://doc.qt.io/qt-5/qpointf.html#operator-2b
     fn add(self, other: QPointF) -> QPointF {
         QPointF {
             x: self.x + other.x,
@@ -818,6 +967,9 @@ impl std::ops::Add for QPointF {
     }
 }
 impl std::ops::AddAssign for QPointF {
+    /// Wrapper around [`operator+=(const QPointF &`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qpointf.html#operator-2b-eq
     fn add_assign(&mut self, other: QPointF) {
         *self = QPointF {
             x: self.x + other.x,
@@ -840,12 +992,16 @@ fn test_qpointf_qrectf() {
 }
 
 cpp_class!(
-    /// Wrapper around QColor
+    /// Wrapper around [`QColor`][class] class.
+    ///
+    /// [class]: https://doc.qt.io/qt-5/qcolor.html
     #[derive(Default, Clone, Copy, PartialEq)]
     pub unsafe struct QColor as "QColor"
 );
 impl QColor {
-    /// Construct a QColor from a string. Refer to the Qt documentation of QColor::setNamedColor
+    /// Wrapper around [`QColor(QLatin1String)`][ctor] constructor.
+    ///
+    /// [ctor]: https://doc.qt.io/qt-5/qcolor.html#QColor-8
     pub fn from_name(name: &str) -> Self {
         let len = name.len();
         let ptr = name.as_ptr();
@@ -853,20 +1009,41 @@ impl QColor {
             return QColor(QLatin1String(ptr, len));
         })
     }
-    /// Refer to the Qt documentation of QColor::fromRgbF
+
+    /// Wrapper around [`fromRgbF(qreal r, qreal g, qreal b, qreal a = 1.0)`][ctor] constructor.
+    ///
+    /// # Wrapper-specific
+    ///
+    /// Alpha is left at default `1.0`. To set it to something other that 1.0, use [`from_rgba_f`][].
+    ///
+    /// [ctor]: https://doc.qt.io/qt-5/qcolor.html#fromRgbF
+    /// [`from_rgba_f`]: #method.from_rgba_f
     pub fn from_rgb_f(r: qreal, g: qreal, b: qreal) -> Self {
         cpp!(unsafe [r as "qreal", g as "qreal", b as "qreal"] -> QColor as "QColor" {
             return QColor::fromRgbF(r, g, b);
         })
     }
-    /// Same as from_rgb_f, but accept an alpha value.
+
+    /// Wrapper around [`fromRgbF(qreal r, qreal g, qreal b, qreal a = 1.0)`][ctor] constructor.
+    ///
+    /// # Wrapper-specific
+    ///
+    /// Same as [`from_rgb_f`][], but accept an alpha value
+    ///
+    /// [ctor]: https://doc.qt.io/qt-5/qcolor.html#fromRgbF
+    /// [`from_rgb_f`]: #method.from_rgb_f
     pub fn from_rgba_f(r: qreal, g: qreal, b: qreal, a: qreal) -> Self {
         cpp!(unsafe [r as "qreal", g as "qreal", b as "qreal", a as "qreal"] -> QColor as "QColor" {
             return QColor::fromRgbF(r, g, b, a);
         })
     }
-    /// Returns the individual component as floating point.
-    /// Refer to the Qt documentation of QColor::getRgbF.
+    /// Wrapper around [`getRgbF(qreal *r, qreal *g, qreal *b, qreal *a = nullptr)`][method] method.
+    ///
+    /// # Wrapper-specific
+    ///
+    /// Returns red, green, blue and alpha components as a tuple, instead of mutable references.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qcolor.html#getRgbF
     pub fn get_rgba(&self) -> (qreal, qreal, qreal, qreal) {
         let res = (0., 0., 0., 0.);
         let (ref r, ref g, ref b, ref a) = res;
@@ -893,7 +1070,9 @@ fn test_qcolor() {
     assert!(blue1 != red1);
 }
 
-/// Wrapper around QSize
+/// Bindings for [`QSize`][class] class.
+///
+/// [class]: https://doc.qt.io/qt-5/qsize.html
 #[repr(C)]
 #[derive(Default, Clone, Copy, PartialEq, Debug)]
 pub struct QSize {
@@ -901,66 +1080,105 @@ pub struct QSize {
     pub height: u32,
 }
 
+/// Bindings for [`QImage::Format`][class] enum class.
+///
+/// [class]: https://doc.qt.io/qt-5/qimage.html#Format-enum
 #[repr(u32)]
 #[derive(Clone, Copy, PartialEq, Debug)]
 #[allow(non_camel_case_types)]
 pub enum ImageFormat {
-    Invalid,
-    Mono,
-    MonoLSB,
-    Indexed8,
-    RGB32,
-    ARGB32,
-    ARGB32_Premultiplied,
-    RGB16,
-    ARGB8565_Premultiplied,
-    RGB666,
-    ARGB6666_Premultiplied,
-    RGB555,
-    ARGB8555_Premultiplied,
-    RGB888,
-    RGB444,
-    ARGB4444_Premultiplied,
-    RGBX8888,
-    RGBA8888,
-    RGBA8888_Premultiplied,
-    BGR30,
-    A2BGR30_Premultiplied,
-    RGB30,
-    A2RGB30_Premultiplied,
-    Alpha8,
-    Grayscale8,
+    Invalid = 0,
+    Mono = 1,
+    MonoLSB = 2,
+    Indexed8 = 3,
+    RGB32 = 4,
+    ARGB32 = 5,
+    ARGB32_Premultiplied = 6,
+    RGB16 = 7,
+    ARGB8565_Premultiplied = 8,
+    RGB666 = 9,
+    ARGB6666_Premultiplied = 10,
+    RGB555 = 11,
+    ARGB8555_Premultiplied = 12,
+    RGB888 = 13,
+    RGB444 = 14,
+    ARGB4444_Premultiplied = 15,
+    RGBX8888 = 16,
+    RGBA8888 = 17,
+    RGBA8888_Premultiplied = 18,
+    BGR30 = 19,
+    A2BGR30_Premultiplied = 20,
+    RGB30 = 21,
+    A2RGB30_Premultiplied = 22,
+    Alpha8 = 23,
+    Grayscale8 = 24,
+    Grayscale16 = 28,
+    RGBX64 = 25,
+    RGBA64 = 26,
+    RGBA64_Premultiplied = 27,
+    BGR888 = 29,
 }
 cpp_class!(
-    /// Wrapper around QImage
+    /// Wrapper around [`QImage`][class] class.
+    ///
+    /// [class]: https://doc.qt.io/qt-5/qimage.html
     pub unsafe struct QImage as "QImage"
 );
 impl QImage {
+    /// Wrapper around [`QImage(const QString &fileName, const char *format = nullptr)`][ctor] constructor.
+    ///
+    /// [ctor]: https://doc.qt.io/qt-5/qimage.html#QImage-8
     pub fn load_from_file(filename: QString) -> Self {
         cpp!(unsafe [filename as "QString"] -> QImage as "QImage" {
             return QImage(filename);
         })
     }
+
+    /// Wrapper around [`QImage(const QSize &, QImage::Format)`][ctor] constructor.
+    ///
+    /// [ctor]: https://doc.qt.io/qt-5/qimage.html#QImage-1
     pub fn new(size: QSize, format: ImageFormat) -> Self {
         cpp!(unsafe [size as "QSize", format as "QImage::Format" ] -> QImage as "QImage" {
             return QImage(size, format);
         })
     }
+
+    /// Wrapper around [`size()`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qimage.html#size
     pub fn size(&self) -> QSize {
         cpp!(unsafe [self as "const QImage*"] -> QSize as "QSize" { return self->size(); })
     }
+
+    /// Wrapper around [`format()`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qimage.html#format
     pub fn format(&self) -> ImageFormat {
         cpp!(unsafe [self as "const QImage*"] -> ImageFormat as "QImage::Format" { return self->format(); })
     }
+
+    /// Wrapper around [`fill(const QColor &)`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qimage.html#fill-1
     pub fn fill(&mut self, color: QColor) {
         cpp!(unsafe [self as "QImage*", color as "QColor"] { self->fill(color); })
     }
+
+    /// Wrapper around [`setPixelColor(const QPoint &, const QColor &)`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qimage.html#setPixelColor
     pub fn set_pixel_color(&mut self, x: u32, y: u32, color: QColor) {
-        cpp!(unsafe [self as "QImage*", x as "int", y as "int", color as "QColor"]
-            { self->setPixelColor(x, y, color); })
+        cpp!(unsafe [self as "QImage*", x as "int", y as "int", color as "QColor"] {
+            self->setPixelColor(x, y, color);
+        })
     }
+
+    /// Wrapper around [`pixelColor(const QPoint &)`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qimage.html#pixelColor
     pub fn get_pixel_color(&mut self, x: u32, y: u32) -> QColor {
-        cpp!(unsafe [self as "QImage*", x as "int", y as "int"] -> QColor as "QColor"
-            { return self->pixelColor(x, y); })
+        cpp!(unsafe [self as "QImage*", x as "int", y as "int"] -> QColor as "QColor" {
+            return self->pixelColor(x, y);
+        })
     }
 }

--- a/qmetaobject/src/qttypes.rs
+++ b/qmetaobject/src/qttypes.rs
@@ -396,7 +396,7 @@ fn test_qdatetime_is_valid() {
 }
 
 cpp_class!(
-/// Wrapper around Qt's QUrl class
+    /// Wrapper around Qt's QUrl class
     #[derive(PartialEq, PartialOrd, Eq, Ord)]
     pub unsafe struct QUrl as "QUrl"
 );
@@ -420,9 +420,10 @@ impl From<QString> for QUrl {
 }
 
 cpp_class!(
-/// Wrapper around Qt's QString class
-#[derive(PartialEq, PartialOrd, Eq, Ord)]
-pub unsafe struct QString as "QString");
+    /// Wrapper around Qt's QString class
+    #[derive(PartialEq, PartialOrd, Eq, Ord)]
+    pub unsafe struct QString as "QString"
+);
 impl QString {
     /// Return a slice containing the UTF-16 data
     pub fn to_slice(&self) -> &[u16] {
@@ -473,9 +474,12 @@ impl std::fmt::Debug for QString {
         write!(f, "{}", self)
     }
 }
+
 cpp_class!(
-/// Wrapper around a QVariant
-#[derive(PartialEq)] pub unsafe struct QVariant as "QVariant");
+    /// Wrapper around a QVariant
+    #[derive(PartialEq)]
+    pub unsafe struct QVariant as "QVariant"
+);
 impl QVariant {
     pub fn to_qbytearray(&self) -> QByteArray {
         cpp!(unsafe [self as "const QVariant*"] -> QByteArray as "QByteArray" {
@@ -585,8 +589,9 @@ where
 }
 
 cpp_class!(
-/// Wrapper around QVariantList
-pub unsafe struct QVariantList as "QVariantList");
+    /// Wrapper around QVariantList
+    pub unsafe struct QVariantList as "QVariantList"
+);
 impl QVariantList {
     pub fn push(&mut self, value: QVariant) {
         cpp!(unsafe [self as "QVariantList*", value as "QVariant"] {
@@ -749,8 +754,10 @@ mod tests {
 }
 
 cpp_class!(
-/// Wrapper around Qt's QModelIndex
-#[derive(PartialEq, Eq)] pub unsafe struct QModelIndex as "QModelIndex");
+    /// Wrapper around Qt's QModelIndex
+    #[derive(PartialEq, Eq)]
+    pub unsafe struct QModelIndex as "QModelIndex"
+);
 impl QModelIndex {
     /// Return the QModelIndex::internalId
     pub fn id(&self) -> usize {
@@ -833,8 +840,10 @@ fn test_qpointf_qrectf() {
 }
 
 cpp_class!(
-/// Wrapper around QColor
-#[derive(Default, Clone, Copy, PartialEq)] pub unsafe struct QColor as "QColor");
+    /// Wrapper around QColor
+    #[derive(Default, Clone, Copy, PartialEq)]
+    pub unsafe struct QColor as "QColor"
+);
 impl QColor {
     /// Construct a QColor from a string. Refer to the Qt documentation of QColor::setNamedColor
     pub fn from_name(name: &str) -> Self {
@@ -923,8 +932,9 @@ pub enum ImageFormat {
     Grayscale8,
 }
 cpp_class!(
-/// Wrapper around QImage
-pub unsafe struct QImage as "QImage");
+    /// Wrapper around QImage
+    pub unsafe struct QImage as "QImage"
+);
 impl QImage {
     pub fn load_from_file(filename: QString) -> Self {
         cpp!(unsafe [filename as "QString"] -> QImage as "QImage" {

--- a/qmetaobject/src/qttypes.rs
+++ b/qmetaobject/src/qttypes.rs
@@ -51,10 +51,9 @@ impl<'a> From<&'a [u8]> for QByteArray {
     fn from(s: &'a [u8]) -> QByteArray {
         let len = s.len();
         let ptr = s.as_ptr();
-        unsafe {
-            cpp!([len as "size_t", ptr as "char*"] -> QByteArray as "QByteArray"
-        { return QByteArray(ptr, len); })
-        }
+        cpp!(unsafe [len as "size_t", ptr as "char*"] -> QByteArray as "QByteArray" {
+            return QByteArray(ptr, len);
+        })
     }
 }
 impl<'a> From<&'a str> for QByteArray {
@@ -73,10 +72,9 @@ impl From<String> for QByteArray {
 impl From<QString> for QByteArray {
     /// Converts a QString to a QByteArray
     fn from(s: QString) -> QByteArray {
-        unsafe {
-            cpp!([s as "QString"] -> QByteArray as "QByteArray"
-            { return std::move(s).toUtf8(); })
-        }
+        cpp!(unsafe [s as "QString"] -> QByteArray as "QByteArray" {
+            return std::move(s).toUtf8();
+        })
     }
 }
 impl Display for QByteArray {
@@ -407,21 +405,17 @@ impl QUrl {
     /// Returns a valid URL from a user supplied qstring if one can be deducted.
     /// In the case that is not possible, an invalid QUrl is returned.
     /// 
-    /// Refer to the documentation for QUrl::fromUserInput.
-    pub fn from_user_input(qstring: QString) -> QUrl {
-        unsafe {
-            cpp!([qstring as "QString"] -> QUrl as "QUrl" {
-                return QUrl::fromUserInput(qstring);
-            })
-        }
+    pub fn from_user_input(user_input: QString) -> QUrl {
+        cpp!(unsafe [user_input as "QString"] -> QUrl as "QUrl" {
+            return QUrl::fromUserInput(user_input);
+        })
     }
 }
-
 impl From<QString> for QUrl {
     fn from(qstring: QString) -> QUrl {
-        unsafe { cpp!([qstring as "QString"] -> QUrl as "QUrl" {
+        cpp!(unsafe [qstring as "QString"] -> QUrl as "QUrl" {
             return QUrl(qstring);
-        })}
+        })
     }
 }
 
@@ -444,9 +438,9 @@ impl QString {
 }
 impl From<QUrl> for QString {
     fn from(qurl: QUrl) -> QString {
-        unsafe { cpp!([qurl as "QUrl"] -> QString as "QString" {
+        cpp!(unsafe [qurl as "QUrl"] -> QString as "QString" {
             return qurl.toString();
-        })}
+        })
     }
 }
 impl<'a> From<&'a str> for QString {
@@ -454,8 +448,9 @@ impl<'a> From<&'a str> for QString {
     fn from(s: &'a str) -> QString {
         let len = s.len();
         let ptr = s.as_ptr();
-        unsafe { cpp!([len as "size_t", ptr as "char*"] -> QString as "QString"
-        { return QString::fromUtf8(ptr, len); })}
+        cpp!(unsafe [len as "size_t", ptr as "char*"] -> QString as "QString" {
+            return QString::fromUtf8(ptr, len);
+        })
     }
 }
 impl From<String> for QString {
@@ -483,76 +478,101 @@ cpp_class!(
 #[derive(PartialEq)] pub unsafe struct QVariant as "QVariant");
 impl QVariant {
     pub fn to_qbytearray(&self) -> QByteArray {
-        // FIXME
-        unsafe {
-            cpp!([self as "const QVariant*"] -> QByteArray as "QByteArray" { return self->toByteArray(); })
-        }
+        cpp!(unsafe [self as "const QVariant*"] -> QByteArray as "QByteArray" {
+            return self->toByteArray();
+        })
     }
 
     pub fn to_bool(&self) -> bool {
-        unsafe { cpp!([self as "const QVariant*"] -> bool as "bool" { return self->toBool(); }) }
+        cpp!(unsafe [self as "const QVariant*"] -> bool as "bool" {
+            return self->toBool();
+        })
     }
+
+    // FIXME: do more wrappers
 }
 impl From<QString> for QVariant {
     fn from(a: QString) -> QVariant {
-        unsafe { cpp!([a as "QString"] -> QVariant as "QVariant" { return QVariant(a); }) }
+        cpp!(unsafe [a as "QString"] -> QVariant as "QVariant" {
+            return QVariant(a);
+        })
     }
 }
 impl From<QByteArray> for QVariant {
     fn from(a: QByteArray) -> QVariant {
-        unsafe { cpp!([a as "QByteArray"] -> QVariant as "QVariant" { return QVariant(a); }) }
+        cpp!(unsafe [a as "QByteArray"] -> QVariant as "QVariant" {
+            return QVariant(a);
+        })
     }
 }
 impl From<QDate> for QVariant {
     fn from(a: QDate) -> QVariant {
-        unsafe { cpp!([a as "QDate"] -> QVariant as "QVariant" { return QVariant(a); }) }
+        cpp!(unsafe [a as "QDate"] -> QVariant as "QVariant" {
+            return QVariant(a);
+        })
     }
 }
 impl From<QTime> for QVariant {
     fn from(a: QTime) -> QVariant {
-        unsafe { cpp!([a as "QTime"] -> QVariant as "QVariant" { return QVariant(a); }) }
+        cpp!(unsafe [a as "QTime"] -> QVariant as "QVariant" {
+            return QVariant(a);
+        })
     }
 }
 impl From<QDateTime> for QVariant {
     fn from(a: QDateTime) -> QVariant {
-        unsafe { cpp!([a as "QDateTime"] -> QVariant as "QVariant" { return QVariant(a); }) }
+        cpp!(unsafe [a as "QDateTime"] -> QVariant as "QVariant" {
+            return QVariant(a);
+        })
     }
 }
-
 impl From<QUrl> for QVariant {
     fn from(a: QUrl) -> QVariant {
-        unsafe { cpp!([a as "QUrl"] -> QVariant as "QVariant" { return QVariant(a); }) }
+        cpp!(unsafe [a as "QUrl"] -> QVariant as "QVariant" {
+            return QVariant(a);
+        })
     }
 }
-
 impl From<QVariantList> for QVariant {
     fn from(a: QVariantList) -> QVariant {
-        unsafe { cpp!([a as "QVariantList"] -> QVariant as "QVariant" { return QVariant(a); }) }
+        cpp!(unsafe [a as "QVariantList"] -> QVariant as "QVariant" {
+            return QVariant(a);
+        })
     }
 }
 impl From<i32> for QVariant {
     fn from(a: i32) -> QVariant {
-        unsafe { cpp!([a as "int"] -> QVariant as "QVariant" { return QVariant(a); }) }
+        cpp!(unsafe [a as "int"] -> QVariant as "QVariant" {
+            return QVariant(a);
+        })
     }
 }
 impl From<u32> for QVariant {
     fn from(a: u32) -> QVariant {
-        unsafe { cpp!([a as "uint"] -> QVariant as "QVariant" { return QVariant(a); }) }
+        cpp!(unsafe [a as "uint"] -> QVariant as "QVariant" {
+            return QVariant(a);
+        })
     }
 }
 impl From<f32> for QVariant {
     fn from(a: f32) -> QVariant {
-        unsafe { cpp!([a as "float"] -> QVariant as "QVariant" { return QVariant(a); }) }
+        cpp!(unsafe [a as "float"] -> QVariant as "QVariant" {
+            return QVariant(a);
+        })
     }
 }
 impl From<f64> for QVariant {
     fn from(a: f64) -> QVariant {
-        unsafe { cpp!([a as "double"] -> QVariant as "QVariant" { return QVariant(a); }) }
+        cpp!(unsafe [a as "double"] -> QVariant as "QVariant" {
+            return QVariant(a);
+        })
     }
 }
 impl From<bool> for QVariant {
     fn from(a: bool) -> QVariant {
-        unsafe { cpp!([a as "bool"] -> QVariant as "QVariant" { return QVariant(a); }) }
+        cpp!(unsafe [a as "bool"] -> QVariant as "QVariant" {
+            return QVariant(a);
+        })
     }
 }
 impl<'a, T> From<&'a T> for QVariant
@@ -569,24 +589,24 @@ cpp_class!(
 pub unsafe struct QVariantList as "QVariantList");
 impl QVariantList {
     pub fn push(&mut self, value: QVariant) {
-        cpp!(unsafe [self as "QVariantList*", value as "QVariant"]
-            { self->append(std::move(value)); }
-        )
+        cpp!(unsafe [self as "QVariantList*", value as "QVariant"] {
+            self->append(std::move(value));
+        })
     }
     pub fn insert(&mut self, index: usize, element: QVariant) {
-        cpp!(unsafe [self as "QVariantList*", index as "size_t", element as "QVariant"]
-            { self->insert(index, std::move(element)); }
-        )
+        cpp!(unsafe [self as "QVariantList*", index as "size_t", element as "QVariant"] {
+            self->insert(index, std::move(element));
+        })
     }
     pub fn remove(&mut self, index: usize) -> QVariant {
-        cpp!(unsafe [self as "QVariantList*", index as "size_t"] -> QVariant as "QVariant"
-            { return self->takeAt(index); }
-        )
+        cpp!(unsafe [self as "QVariantList*", index as "size_t"] -> QVariant as "QVariant" {
+            return self->takeAt(index);
+        })
     }
     pub fn len(&self) -> usize {
-        unsafe {cpp!([self as "QVariantList*"] -> usize as "size_t"
-            { return self->size(); }
-        )}
+        cpp!(unsafe [self as "QVariantList*"] -> usize as "size_t" {
+            return self->size();
+        })
     }
     pub fn is_empty(&self) -> bool {
         self.len() == 0
@@ -597,17 +617,17 @@ impl Index<usize> for QVariantList {
     type Output = QVariant;
     fn index(&self, index: usize) -> &QVariant {
         assert!(index < self.len());
-        unsafe { &*cpp!([self as "QVariantList*", index as "size_t"] -> *const QVariant as "const QVariant*"
-            { return &self->at(index); }
-        )}
+        unsafe { &*cpp!([self as "QVariantList*", index as "size_t"] -> *const QVariant as "const QVariant*" {
+            return &self->at(index);
+        })}
     }
 }
 impl IndexMut<usize> for QVariantList {
     fn index_mut(&mut self, index: usize) -> &mut QVariant {
         assert!(index < self.len());
-        unsafe { &mut *cpp!([self as "QVariantList*", index as "size_t"] -> *mut QVariant as "QVariant*"
-            { return &(*self)[index]; }
-        )}
+        unsafe { &mut *cpp!([self as "QVariantList*", index as "size_t"] -> *mut QVariant as "QVariant*" {
+            return &(*self)[index];
+        })}
     }
 }
 
@@ -734,18 +754,16 @@ cpp_class!(
 impl QModelIndex {
     /// Return the QModelIndex::internalId
     pub fn id(&self) -> usize {
-        unsafe {
-            cpp!([self as "const QModelIndex*"] -> usize as "uintptr_t" { return self->internalId(); })
-        }
+        cpp!(unsafe [self as "const QModelIndex*"] -> usize as "uintptr_t" { return self->internalId(); })
     }
     pub fn column(&self) -> i32 {
-        unsafe { cpp!([self as "const QModelIndex*"] -> i32 as "int" { return self->column(); }) }
+        cpp!(unsafe [self as "const QModelIndex*"] -> i32 as "int" { return self->column(); })
     }
     pub fn row(&self) -> i32 {
-        unsafe { cpp!([self as "const QModelIndex*"] -> i32 as "int" { return self->row(); }) }
+        cpp!(unsafe [self as "const QModelIndex*"] -> i32 as "int" { return self->row(); })
     }
     pub fn is_valid(&self) -> bool {
-        unsafe { cpp!([self as "const QModelIndex*"] -> bool as "bool" { return self->isValid(); }) }
+        cpp!(unsafe [self as "const QModelIndex*"] -> bool as "bool" { return self->isValid(); })
     }
 }
 

--- a/qmetaobject/tests/tests.rs
+++ b/qmetaobject/tests/tests.rs
@@ -376,7 +376,7 @@ fn qpointer_properties_incompatible() {
 }
 
 #[test]
-fn singleshot() {
+fn test_single_shot() {
     let _lock = TEST_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
 
     let engine = Rc::new(QmlEngine::new());
@@ -388,7 +388,7 @@ fn singleshot() {
 }
 
 #[test]
-fn test_queud_callback() {
+fn test_queued_callback() {
     let _lock = TEST_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
 
     let engine = Rc::new(QmlEngine::new());
@@ -742,7 +742,7 @@ fn threading() {
                 });
             });
             std::thread::spawn(move || {
-                // do stuff asynchroniously ...
+                // do stuff asynchronously ...
                 let r = QString::from("Hello ".to_owned() + &name);
                 set_value(r);
             }).join().unwrap();

--- a/qmetaobject_impl/src/lib.rs
+++ b/qmetaobject_impl/src/lib.rs
@@ -58,13 +58,13 @@ fn get_crate(input: &syn::DeriveInput) -> impl quote::ToTokens {
     quote!(::qmetaobject)
 }
 
-/// Implementation of #[derice(QObject)]
+/// Implementation of #[derive(QObject)]
 #[proc_macro_derive(QObject, attributes(QMetaObjectCrate, qt_base_class))]
 pub fn qobject_impl(input: TokenStream) -> TokenStream {
     qobject_impl::generate(input, true)
 }
 
-/// Implementation of #[derice(QGadget)]
+/// Implementation of #[derive(QGadget)]
 #[proc_macro_derive(QGadget, attributes(QMetaObjectCrate))]
 pub fn qgadget_impl(input: TokenStream) -> TokenStream {
     qobject_impl::generate(input, false)
@@ -82,7 +82,7 @@ pub fn qrc_internal(input: TokenStream) -> TokenStream {
     qrc_impl::process_qrc(input)
 }
 
-/// Implementation of #[derice(SimpleListItem)]
+/// Implementation of #[derive(SimpleListItem)]
 #[proc_macro_derive(SimpleListItem, attributes(QMetaObjectCrate))]
 pub fn simplelistitem(input: TokenStream) -> TokenStream {
     simplelistitem_impl::derive(input)

--- a/qmetaobject_impl/src/qrc_impl.rs
+++ b/qmetaobject_impl/src/qrc_impl.rs
@@ -136,7 +136,7 @@ impl TreeNode {
             // insert into iteself
             contents.extend(match node {
                 TreeNode::Directory(contents, _) => contents,
-                _ => panic!("merge file and direcotry?"),
+                _ => panic!("merge file and directory?"),
             });
             return;
         }
@@ -323,7 +323,7 @@ fn expand_macro(func: &syn::Ident, data: Data) -> TokenStream {
         files,
     } = data;
 
-    // Workaround performence issue with proc_macro2 and Rust 1.29:
+    // Workaround performance issue with proc_macro2 and Rust 1.29:
     // quote!(#(#payload),*) uses proc_macro2::TokenStream::extend, which is O(n²) with rust 1.29
     // since the payload array can be quite large, this is completely unacceptable.
     let payload = ::proc_macro2::TokenStream::from_iter(payload.iter().map(|x| quote!(#x,)));


### PR DESCRIPTION
Hi!
First of all, thanks for your wonderful work. I appreciate how ambitious this project is.

Still, I can see, there is much to be done, and a lot to consider in terms of future directions.

I would love to see more Qt bindings (both low- and high-level) in Rust, although I've read articles on this topic, thus I understand how troublesome that task would be.

So, I'm trying to get involved, and I decided to start with the usual basics: reading code, getting myself comfortable with it, while fixing stuff in the process.

Here is the summary of my findings so far:
 - unified `unsafe { cpp!(...)}` combo into `cpp!(unsafe [..] {})`
 - explained 513 Event Type with a doc comment
 - prettified `cpp_macro!` invocations
 - unified doc strings of bindings and wrappers, added links to Qt docs
 - fixed missing `mut` / `ref mut` in one place
 - other minor stuff.

Doctests via `cargo test` are passing; documentation via `cargo docs` builds OK, links in docs seem al-right.