### PR TITLE
Cosmit

### DIFF
--- a/examples/graph/src/main.qml
+++ b/examples/graph/src/main.qml
@@ -49,7 +49,6 @@
 ****************************************************************************/
 
 import QtQuick 2.0
-
 import Graph 1.0
 
 Item {
@@ -70,7 +69,7 @@ Item {
                 appendSample(newSample(i));
         }
 
-        property int offset: 100;
+        property int offset: 100
     }
 
     Timer {
@@ -82,7 +81,6 @@ Item {
             graph.removeFirstSample();
             graph.appendSample(graph.newSample(++graph.offset));
         }
-
     }
 
     Rectangle {
@@ -91,5 +89,4 @@ Item {
         border.color: "black"
         border.width: 2
     }
-
 }

--- a/examples/qmlextensionplugins/README
+++ b/examples/qmlextensionplugins/README
@@ -1,5 +1,5 @@
-This example is showing that you can use plugins with qml builder.
-It is base on the `qmlextensionplugins` example found in the qtdeclarative
+This example shows how you can use plugins with qml builder.
+It is based on the `qmlextensionplugins` example found in the qtdeclarative
 source code. It needs the QML files from that example in the Qt source tree.
 
 Build with:

--- a/examples/qmlextensionplugins/src/lib.rs
+++ b/examples/qmlextensionplugins/src/lib.rs
@@ -46,7 +46,7 @@ impl TimeModel {
                 if *lock {
                     break;
                 }
-                // We just wait on the condition variable for 1 second to similate a one second timer
+                // We just wait on the condition variable for 1 second to simulate a one second timer
                 let lock = arc2
                     .abort_condvar
                     .wait_timeout(lock, std::time::Duration::from_millis(1000))

--- a/examples/todos/README
+++ b/examples/todos/README
@@ -2,5 +2,3 @@ This example is based on a rust-qt-binding-generator example from Jos van den Oe
 https://github.com/KDE/rust-qt-binding-generator/tree/9822dcef071f8c6d6ec2f6b39bab436613493221/examples/todos
 The file main.qml is imported unmodified, and the file implementation.rs was used and adapted to
 the qmetaobject crate
-
-

--- a/examples/todos/main.qml
+++ b/examples/todos/main.qml
@@ -22,7 +22,7 @@
 import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Layouts 1.3
-import RustCode 1.0;
+import RustCode 1.0
 
 ApplicationWindow {
     visible: true

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -7,7 +7,6 @@ mod implementation;
 
 qrc!(my_resource,
     "todos/qml" {
-      //  "../main.qml" as "main.qml",
         "main.qml",
     },
 );

--- a/qmetaobject/src/lib.rs
+++ b/qmetaobject/src/lib.rs
@@ -168,9 +168,6 @@ pub use lazy_static::*;
 #[macro_export]
 macro_rules! qmetaobject_lazy_static { ($($t:tt)*) => { lazy_static!($($t)*) } }
 
-//#[macro_use]
-//extern crate bitflags;
-
 use std::cell::RefCell;
 use std::os::raw::{c_char, c_void};
 

--- a/qmetaobject/tests/models.rs
+++ b/qmetaobject/tests/models.rs
@@ -32,23 +32,25 @@ fn simple_model() {
         pub a: QString,
         pub b: u32,
     }
-    // FIXME! why vec! here?
     let model: qmetaobject::listmodel::SimpleListModel<TM> =
-        (vec![TM { a: "hello".into(), b: 1 }]).into_iter().collect();
+        std::iter::once(TM { a: "hello".into(), b: 42 }).collect();
     assert!(do_test(
         model,
-        "Item {
-            Repeater{
+        "
+        Item {
+            Repeater {
                 id: rep;
-                model:_obj;
+                model: _obj
                 Text {
-                    text: a + b;
+                    text: a + b
                 }
             }
             function doTest() {
                 console.log('simple_model:', rep.count, rep.itemAt(0).text);
-                return rep.count === 1 && rep.itemAt(0).text === 'hello1';
-            }}"
+                return rep.count === 1 && rep.itemAt(0).text === 'hello42';
+            }
+        }
+        "
     ));
 }
 
@@ -86,19 +88,25 @@ fn simple_model_remove() {
 
     assert!(do_test(
         obj,
-        "Item {
+        "
+        Item {
             Repeater{
-                id: rep;
-                model:_obj.list;
+                id: rep
+                model: _obj.list
                 Text {
-                    text: val;
+                    text: val
                 }
             }
             function doTest() {
                 _obj.remove(1);
                 console.log('simple_model_remove', rep.count, rep.itemAt(0).text, rep.itemAt(1).text, rep.itemAt(2).text);
-                return rep.count === 3 && rep.itemAt(0).text === '10' && rep.itemAt(1).text === '12'  && rep.itemAt(2).text === '13';
-            }}"
+                return rep.count === 3
+                    && rep.itemAt(0).text === '10'
+                    && rep.itemAt(1).text === '12'
+                    && rep.itemAt(2).text === '13';
+            }
+        }
+        "
     ));
 }
 

--- a/qmetaobject/tests/tests.rs
+++ b/qmetaobject/tests/tests.rs
@@ -123,29 +123,38 @@ fn call_method() {
     let obj = MyObject::default();
     assert!(do_test(
         obj,
-        "Item {
-        function doTest() {
-            return _obj.concatenate_strings('abc', 'def', 'hij') == 'abcdefhij';
-        }}"
+        r"
+        Item {
+            function doTest() {
+                return _obj.concatenate_strings('abc', 'def', 'hij') == 'abcdefhij';
+            }
+        }
+        "
     ));
 
     let obj = MyObject::default();
     assert!(do_test(
         obj,
-        "Item {
-        function doTest() {
-            return _obj.concatenate_strings(123, 456, 789) == '123456789';
-        }}"
+        r"
+        Item {
+            function doTest() {
+                return _obj.concatenate_strings(123, 456, 789) == '123456789';
+            }
+        }
+        "
     ));
 
     let obj = MyObject::default();
     assert!(do_test(
         obj,
-        "Item {
-        function doTest() {
-            _obj.prop_y = '8887'
-            return _obj.method_out_of_line('hello') == '8887hello';
-        }}"
+        r"
+        Item {
+            function doTest() {
+                _obj.prop_y = '8887';
+                return _obj.method_out_of_line('hello') == '8887hello';
+            }
+        }
+        "
     ));
 }
 
@@ -168,16 +177,19 @@ fn register_type() {
     let obj = MyObject::default(); // not used but needed for do_test
     assert!(do_test(
         obj,
-        "import TestRegister 1.0;
+        r"
+        import TestRegister 1.0
+
         Item {
             RegisteredObj {
-                id: test;
-                value: 55;
+                id: test
+                value: 55
             }
             function doTest() {
-                return test.square(66) === 55*66;
+                return test.square(66) === 55 * 66;
             }
-        }"
+        }
+        "
     ));
 }
 
@@ -204,12 +216,15 @@ fn register_singleton_instance() {
     let obj = MyObject::default(); // not used but needed for do_test
     assert!(do_test(
         obj,
-        "import TestRegister 1.0;
+        r"
+        import TestRegister 1.0;
+
         Item {
             function doTest() {
                 return RegisterSingletonInstanceObj.get_value() === 123;
             }
-        }"
+        }
+        "
     ));
 }
 
@@ -238,12 +253,15 @@ fn register_singleton_type() {
     let obj = MyObject::default(); // not used but needed for do_test
     assert!(do_test(
         obj,
-        "import TestRegister 1.0;
+        r"
+        import TestRegister 1.0;
+
         Item {
             function doTest() {
                 return RegisterSingletonTypeObj.get_value2() === 456;
             }
-        }"
+        }
+        "
     ));
 }
 
@@ -264,10 +282,15 @@ fn simple_gadget() {
 
     assert!(do_test_variant(
         my_gadget.to_qvariant(),
-        "Item { function doTest() {
-        return _obj.strValue == 'plop' && _obj.numValue == 33
-            && _obj.concat(':') == 'plop:33';
-    }}"
+        r"
+        Item {
+            function doTest() {
+                return _obj.strValue == 'plop'
+                    && _obj.numValue == 33
+                    && _obj.concat(':') == 'plop:33';
+            }
+        }
+        "
     ));
 }
 
@@ -285,20 +308,23 @@ fn qobject_properties() {
     my_obj.prop_object.borrow_mut().prop_x = 56;
     assert!(do_test(
         my_obj,
-        "Item {
-        property int yo: _obj.prop_object.prop_x;
-        function doTest() {
-            if (yo !== 56) {
-                console.log('ERROR #1: 56 != ' +  yo)
-                return false;
+        r"
+        Item {
+            property int yo: _obj.prop_object.prop_x;
+            function doTest() {
+                if (yo !== 56) {
+                    console.log('ERROR #1: 56 != ' +  yo);
+                    return false;
+                }
+                _obj.prop_object.prop_x = 4545;
+                if (yo !== 4545) {
+                    console.log('ERROR #2: 4545 != ' +  yo);
+                    return false;
+                }
+                return _obj.subx() === 4545;
             }
-            _obj.prop_object.prop_x = 4545;
-            if (yo !== 4545) {
-                console.log('ERROR #2: 4545 != ' +  yo)
-                return false;
-            }
-            return _obj.subx() === 4545;
-        }}"
+        }
+        "
     ));
 }
 
@@ -325,23 +351,27 @@ fn qpointer_properties() {
     );
     assert!(do_test(
         my_obj,
-        "import SomeObjectLib 1.0
+        "
+        import SomeObjectLib 1.0
+
         Item {
-        SomeObject { id: some }
-        function doTest() {
-            if(_obj.prop != null) {
-                return false
+            SomeObject { id: some }
+            function doTest() {
+                if(_obj.prop !== null) {
+                    return false;
+                }
+                _obj.prop = some;
+                if(_obj.prop !== some) {
+                    return false;
+                }
+                _obj.prop = null;
+                if(_obj.prop !== null) {
+                    return false;
+                }
+                return true;
             }
-            _obj.prop = some
-            if(_obj.prop != some) {
-                return false
-            }
-            _obj.prop = null
-            if(_obj.prop != null) {
-                return false
-            }
-            return true
-        }}"
+        }
+        "
     ));
 }
 
@@ -354,11 +384,14 @@ fn qpointer_properties_incompatible() {
         CStr::from_bytes_with_nul(b"ObjectWithSome\0").unwrap(),
     );
     assert!(test_loading_logs(
-        "import SomeObjectLib 1.0
+        "
+        import SomeObjectLib 1.0
+
         Item {
-        Text { id: some }
-        ObjectWithSome { prop: some }
-        }",
+            Text { id: some }
+            ObjectWithSome { prop: some }
+        }
+        ",
         "Unable to assign QQuickText to SomeObject"
     ));
 }
@@ -411,11 +444,14 @@ fn getter() {
     let my_obj = ObjectWithGetter::default();
     assert!(do_test(
         my_obj,
-        "Item {
-        function doTest() {
-            return _obj.prop_x === 85 && _obj.prop_y == 'foo'
+        "
+        Item {
+            function doTest() {
+                return _obj.prop_x === 85
+                    && _obj.prop_y == 'foo';
+            }
         }
-    }"
+        "
     ));
 }
 
@@ -447,34 +483,34 @@ fn setter() {
     let my_obj = ObjectWithGetter::default();
     assert!(do_test(
         my_obj,
-        "Item {
-        property var test: '' + _obj.prop_x + _obj.prop_y;
-        function doTest() {
-            if (test != '0') {
-                console.log('FAILURE #1', test);
-                return false;
+        "
+        Item {
+            property var test: '' + _obj.prop_x + _obj.prop_y;
+            function doTest() {
+                if (test !== '0') {
+                    console.log('FAILURE #1', test);
+                    return false;
+                }
+                _obj.prop_x = 96;
+                if (test !== '96') {
+                    console.log('FAILURE #2', test);
+                    return false;
+                }
+                _obj.prop_y = 'hello';
+                if (test !== '96hello') {
+                    console.log('FAILURE #3', test);
+                    return false;
+                }
+                _obj.prop_x_setter(88);
+                _obj.prop_y_setter('world');
+                if (test !== '88world') {
+                    console.log('FAILURE #4', test);
+                    return false;
+                }
+                return true;
             }
-            _obj.prop_x = 96;
-            if (test != '96') {
-                console.log('FAILURE #2', test);
-                return false;
-            }
-            _obj.prop_y = 'hello';
-            if (test != '96hello') {
-                console.log('FAILURE #3', test);
-                return false;
-            }
-
-            _obj.prop_x_setter(88);
-            _obj.prop_y_setter('world');
-            if (test != '88world') {
-                console.log('FAILURE #4', test);
-                return false;
-            }
-
-            return true;
         }
-    }"
+        "
     ));
 }
 
@@ -695,20 +731,24 @@ fn enum_properties() {
     let my_obj = MyObject::default();
     assert!(do_test(
         my_obj,
-        "import MyEnumLib 1.0
+        "
+        import MyEnumLib 1.0
+
         Item {
-        function doTest() {
-            if(MyEnum.None != 0) {
-                return false;
+            function doTest() {
+                if(MyEnum.None !== 0) {
+                    return false;
+                }
+                if(MyEnum.First !== 1) {
+                    return false;
+                }
+                if(MyEnum.Four !== 4) {
+                    return false;
+                }
+                return true;
             }
-            if(MyEnum.First != 1) {
-                return false;
-            }
-            if(MyEnum.Four != 4) {
-                return false;
-            }
-            return true;
-        }}"
+        }
+        "
     ));
 }
 
@@ -826,7 +866,11 @@ fn test_future() {
 #[test]
 fn create_component() {
     let _lock = lock_for_test();
-    let qml_text = "import QtQuick 2.0\nItem{}".to_owned();
+    let qml_text = "
+        import QtQuick 2.0
+
+        Item {}
+    ";
 
     let engine = QmlEngine::new();
     let mut component = QmlComponent::new(&engine);

--- a/qmetaobject_impl/src/qobject_impl.rs
+++ b/qmetaobject_impl/src/qobject_impl.rs
@@ -928,7 +928,7 @@ fn is_valid_repr_attribute(attribute: &syn::Attribute) -> bool {
             if list.path.is_ident("repr") && list.nested.len() == 1 {
                 match &list.nested[0] {
                     syn::NestedMeta::Meta(syn::Meta::Path(word)) => {
-                        const ACCEPTABLES: &[&str; 6] = &["u8", "u16", "u32", "i8", "i16", "i32"];
+                        const ACCEPTABLES: &[&str] = &["u8", "u16", "u32", "i8", "i16", "i32"];
                         ACCEPTABLES.iter().any(|w| word.is_ident(w))
                     }
                     _ => false,

--- a/qmetaobject_impl/src/qrc_impl.rs
+++ b/qmetaobject_impl/src/qrc_impl.rs
@@ -318,7 +318,6 @@ impl Data {
             assert_eq!(p.len_utf16(), 1, "Surrogate pair not supported");
             push_u16_be(&mut self.names, p as u16);
         }
-        //println!("NAME {} -> {}", offset, name.string);
         offset as u32
     }
 }
@@ -368,7 +367,6 @@ fn expand_macro(func: TargetFunc, data: Data) -> TokenStream {
             });
         }
     };
-    //println!("{}", q.to_string());
     q.into()
 }
 


### PR DESCRIPTION
Minor typo fixed, clean up whitespaces etc.

In tests, I reformatted most of QML examples into idiomatic QML style.
Fixed 'FIXME! why vec! here?' with `std::iter::once()`.
Replaced coercing JS comparations with strict ones (`===` and `!==`).

To be merged after #82, because it is based on that branch.