### PR TITLE
Futures: typos, code style, docs

### DIFF
--- a/qmetaobject/src/future.rs
+++ b/qmetaobject/src/future.rs
@@ -44,14 +44,18 @@ cpp! {{
             Q_UNUSED(e);
             woken = false;
             // future must not be polled after it returned `Poll::Ready`
-            if (completed) return;
+            if (completed) {
+                return;
+            }
             completed = rust!(ProcessQtEvent [
                 this: *const () as "Waker*",
                 future: *mut dyn Future<Output=()> as "TraitObject"
             ] -> bool as "bool" {
                 poll_with_qt_waker(this, Pin::new_unchecked(&mut *future))
             });
-            if (completed) deref();
+            if (completed) {
+                deref();
+            }
         }
         void deref() {
             if (!--ref) {
@@ -59,7 +63,9 @@ cpp! {{
             }
         }
         void wake() {
-            if (woken) return;
+            if (woken) {
+                return;
+            }
             woken = true;
             QApplication::postEvent(this, new QEvent(QEvent::User));
         }

--- a/qmetaobject/src/future.rs
+++ b/qmetaobject/src/future.rs
@@ -39,6 +39,7 @@ cpp! {{
         bool woken = false;
         bool completed = false;
         QAtomicInt refs = 0;
+
         void customEvent(QEvent *e) override {
             Q_UNUSED(e);
             woken = false;
@@ -56,11 +57,13 @@ cpp! {{
                 deref();
             }
         }
+
         void deref() {
             if (!--refs) {
                 deleteLater();
             }
         }
+
         void wake() {
             if (woken) {
                 return;
@@ -68,6 +71,7 @@ cpp! {{
             woken = true;
             QApplication::postEvent(this, new QEvent(QEvent::User));
         }
+
         ~Waker() {
             rust!(QtDestroyFuture [future: *mut dyn Future<Output=()> as "TraitObject"] {
                 std::mem::drop(Box::from_raw(future))

--- a/qmetaobject/src/future.rs
+++ b/qmetaobject/src/future.rs
@@ -45,8 +45,10 @@ cpp! {{
             woken = false;
             // future must not be polled after it returned `Poll::Ready`
             if (completed) return;
-            completed = rust!(ProcessQtEvent [this: *const() as "Waker*",
-                future : *mut dyn Future<Output=()> as "TraitObject"] -> bool as "bool" {
+            completed = rust!(ProcessQtEvent [
+                this: *const () as "Waker*",
+                future: *mut dyn Future<Output=()> as "TraitObject"
+            ] -> bool as "bool" {
                 poll_with_qt_waker(this, Pin::new_unchecked(&mut *future))
             });
             if (completed) deref();
@@ -62,7 +64,7 @@ cpp! {{
             QApplication::postEvent(this, new QEvent(QEvent::User));
         }
         ~Waker() {
-            rust!(QtDestroyFuture [future : *mut dyn Future<Output=()> as "TraitObject"] {
+            rust!(QtDestroyFuture [future: *mut dyn Future<Output=()> as "TraitObject"] {
                 std::mem::drop(Box::from_raw(future))
             });
         }

--- a/qmetaobject/src/future.rs
+++ b/qmetaobject/src/future.rs
@@ -103,7 +103,7 @@ unsafe fn poll_with_qt_waker(waker: *const (), future: Pin<&mut dyn Future<Outpu
 /// The arguments of the signal need to implement `Clone`, and the Output of the future is a tuple
 /// containing the arguments of the signal (or the empty tuple if there are none.)
 ///
-/// The future will be ready as soon as the signal is emited.
+/// The future will be ready as soon as the signal is emitted.
 ///
 /// This is unsafe for the same reason that connections::connect is unsafe.
 pub unsafe fn wait_on_signal<Args: SignalArgArrayToTuple>(

--- a/qmetaobject/src/future.rs
+++ b/qmetaobject/src/future.rs
@@ -98,6 +98,7 @@ pub fn execute_async(f: impl Future<Output = ()> + 'static) {
     }
 }
 
+// SAFETY: caller must ensure that given future hasn't returned Poll::Ready earlier.
 unsafe fn poll_with_qt_waker(waker: *const (), future: Pin<&mut dyn Future<Output = ()>>) -> bool {
     cpp!([waker as "Waker*"] { waker->ref++; });
     let waker = std::task::RawWaker::new(waker, &QT_WAKER_VTABLE);

--- a/qmetaobject/src/future.rs
+++ b/qmetaobject/src/future.rs
@@ -105,7 +105,9 @@ unsafe fn poll_with_qt_waker(waker: *const (), future: Pin<&mut dyn Future<Outpu
 ///
 /// The future will be ready as soon as the signal is emitted.
 ///
-/// This is unsafe for the same reason that connections::connect is unsafe.
+/// This is unsafe for the same reason that [`connections::connect`][] is unsafe.
+///
+/// [`connections::connect`]: ../connections/fn.connect.html
 pub unsafe fn wait_on_signal<Args: SignalArgArrayToTuple>(
     sender: *const c_void,
     signal: crate::connections::CppSignal<Args>,

--- a/qmetaobject/src/future.rs
+++ b/qmetaobject/src/future.rs
@@ -35,7 +35,6 @@ static QT_WAKER_VTABLE: std::task::RawWakerVTable = unsafe {
 
 cpp! {{
     struct Waker : QObject {
-    public:
         TraitObject future;
         bool woken = false;
         bool completed = false;


### PR DESCRIPTION
Started as fixing minor typo; ended up documenting stuff myself.

It is outstanding how flexible both systems are, and how you bridged them together in just a literally a hundred lines of Rust/C++ code.

I learned _a lot_ since I last committed here — about C++ standards, internals, stdlib; LLVM bitcode and VTable representation; about Rust async ecosystem; about Qt/KDE development, governance and management — and yet there so much to be learnt.

Thinking about it... in terms of Gerrit code review, these commits might just as well have become ten separate reviewable 'changes' linked together by a named branch. Ughh, it's so hard to get used to its flow after so many years of happy githubbing. :thinking: 