### PR TITLE
Switch all packages to Rust 2018 edition

### DIFF
--- a/examples/graph/Cargo.toml
+++ b/examples/graph/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "graph"
 version = "0.1.0"
+edition = "2018"
 authors = ["Olivier Goffart <ogoffart@woboq.com>"]
 build = "build.rs"
 

--- a/examples/graph/src/nodes.rs
+++ b/examples/graph/src/nodes.rs
@@ -2,7 +2,7 @@ use qmetaobject::scenegraph::SGNode;
 use qmetaobject::{QColor, QQuickItem, QRectF};
 
 qrc! {
-    init_ressource,
+    init_resource,
     "scenegraph/graph" {
 //        "main.qml",
         "shaders/noisy.vsh",
@@ -25,7 +25,7 @@ cpp! {{
 pub enum NoisyNode {}
 
 pub fn create_noisy_node(s: &mut SGNode<NoisyNode>, ctx: &dyn QQuickItem) {
-    init_ressource();
+    init_resource();
     let item_ptr = ctx.get_cpp_object();
     cpp!(unsafe [s as "NoisyNode**", item_ptr as "QQuickItem*"] {
         if (!*s && item_ptr) {
@@ -52,7 +52,7 @@ pub fn update_grid_node(s: &mut SGNode<GridNode>, rect: QRectF) {
 
 pub enum LineNode {}
 pub fn create_line_node(s: &mut SGNode<LineNode>, size: f32, spread: f32, color: QColor) {
-    init_ressource();
+    init_resource();
     cpp!(unsafe [s as "LineNode**", size as "float", spread as "float", color as "QColor"] {
         if (!*s) *s = new LineNode(size, spread, color);
     });

--- a/examples/qmlextensionplugins/Cargo.toml
+++ b/examples/qmlextensionplugins/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "qmlextensionplugins"
 version = "0.1.0"
+edition = "2018"
 authors = ["Olivier Goffart <ogoffart@woboq.com>"]
 
 [lib]
@@ -10,4 +11,3 @@ crate-type = ["dylib"]
 [dependencies]
 qmetaobject = { path = "../../qmetaobject"}
 chrono = "^0.4"
-

--- a/examples/todos/Cargo.toml
+++ b/examples/todos/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "todos"
 version = "0.1.0"
-authors = ["Olivier Goffart <ogoffart@woboq.com>"]
 edition = "2018"
+authors = ["Olivier Goffart <ogoffart@woboq.com>"]
 
 [dependencies]
 qmetaobject = { path = "../../qmetaobject"}


### PR DESCRIPTION
Some packages (2 out of 5, both are examples) were still using default
edition, which is Rust 2015. It started causing problems as soon as
`cpp` crate bumped patch version to 0.5.5 only to start using ::core
paths instead of ::std, which -- without explicitly adding the line
`extern crate core;` to the top of main.rs file -- naturally fails
in Rust 2015.

Since most of the project already using 2018 edition, it was more
reasonable to upgrade edition for these packages, than try to
accommodate `core` in code and documentation.

Fixes #108

