### PR TITLE
Fix deprication warning for QDateTime from a QDate

### DIFF
--- a/qmetaobject/src/qttypes.rs
+++ b/qmetaobject/src/qttypes.rs
@@ -315,7 +315,11 @@ impl QDateTime {
     /// [ctor]: https://doc.qt.io/qt-5/qdatetime.html#QDateTime-1
     pub fn from_date(date: QDate) -> Self {
         cpp!(unsafe [date as "QDate"] -> QDateTime as "QDateTime" {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+            return date.startOfDay();
+#else
             return QDateTime(date);
+#endif
         })
     }
 


### PR DESCRIPTION
Just cleaning up warnings. 

Qt 5.15 deprecated `QDateTime(const QDate &);` and recommends migrating to `QDate::startOfDay()`. Its scheduled for removal in Qt 6.
