### PR TITLE
Add WebEngineView support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,11 +5,11 @@ environment:
   - TARGET: x86_64-pc-windows-msvc
     ARCH: amd64
     VS: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat
-    QTDIR: C:\Qt\5.10\msvc2017_64
+    QTDIR: C:\Qt\5.12\msvc2017_64
   - TARGET: i686-pc-windows-msvc
     ARCH: x86
     VS: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat
-    QTDIR: C:\Qt\5.11\msvc2015
+    QTDIR: C:\Qt\5.12\msvc2017
 #  - TARGET: i686-pc-windows-gnu
 #    MSYS_BITS: 32
 #    QTDIR: C:\Qt\5.10\mingw53_32

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
     - sudo apt-get update
 
 install:
-    - sudo apt-get install -y -qq qt${QT_VERSION}base qt${QT_VERSION}declarative g++-7 mesa-common-dev
+    - sudo apt-get install -y -qq qt${QT_VERSION}base qt${QT_VERSION}declarative qt${QT_VERSION}webengine  g++-7 mesa-common-dev
     - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 90;
 
 before_script:
@@ -31,3 +31,4 @@ script:
     - (cd examples/todos && cargo build)
     - (cd examples/qmlextensionplugins && cargo build)
     - (cd examples/graph && cargo build)
+    - (cd examples/webengine && cargo build)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,5 @@ members = [
     'examples/todos',
     'examples/graph',
     'examples/qmlextensionplugins',
+    'examples/webengine',
 ]

--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ Enables interoperability of `QDate` and `QTime` with Rust [`chrono`](https://cra
 
 This feature is disabled by default.
 
+### `webengine`
+
+Enables `QtWebEngine` functionality. For more details see the [example](./examples/webengine).
+
+This feature is disabled by default.
+
 ## What if a binding for the Qt C++ API you want to use is missing?
 
 It is quite likely that you would like to call a particular Qt function which is not wrapped by

--- a/examples/webengine/Cargo.toml
+++ b/examples/webengine/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "webengine"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+qmetaobject = { path = "../../qmetaobject", features = ["webengine"] }

--- a/examples/webengine/index.html
+++ b/examples/webengine/index.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Hello from <b>WebEngineView</b>
+</body>
+</html>

--- a/examples/webengine/main.qml
+++ b/examples/webengine/main.qml
@@ -1,0 +1,14 @@
+import QtQuick 2.6;
+import QtQuick.Window 2.0;
+import QtWebEngine 1.4
+
+Window {
+    visible: true
+    title: "WebEngineView"
+    width: 800
+    height: 600
+    WebEngineView {
+        anchors.fill: parent
+        url: "qrc:/webengine/index.html"
+    }
+}

--- a/examples/webengine/src/main.rs
+++ b/examples/webengine/src/main.rs
@@ -1,0 +1,17 @@
+extern crate qmetaobject;
+use qmetaobject::*;
+
+qrc!(my_resource,
+    "webengine" {
+        "main.qml",
+        "index.html",
+    },
+);
+
+fn main() {
+    webengine::initialize();
+    my_resource();
+    let mut engine = QmlEngine::new();
+    engine.load_file("qrc:/webengine/main.qml".into());
+    engine.exec();
+}

--- a/qmetaobject/Cargo.toml
+++ b/qmetaobject/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/woboq/qmetaobject-rs"
 [features]
 default = ["log"]
 chrono_qdatetime = ["chrono"]
+webengine = []
 
 [dependencies]
 qmetaobject_impl = { path = "../qmetaobject_impl", version = "=0.1.4"}

--- a/qmetaobject/build.rs
+++ b/qmetaobject/build.rs
@@ -85,4 +85,7 @@ fn main() {
     println!("cargo:rustc-link-lib{}=Qt{}Core", macos_lib_search, macos_lib_framework);
     println!("cargo:rustc-link-lib{}=Qt{}Quick", macos_lib_search, macos_lib_framework);
     println!("cargo:rustc-link-lib{}=Qt{}Qml", macos_lib_search, macos_lib_framework);
+    if cfg!(feature = "webengine") {
+        println!("cargo:rustc-link-lib{}=Qt{}WebEngine", macos_lib_search, macos_lib_framework);
+    }
 }

--- a/qmetaobject/src/lib.rs
+++ b/qmetaobject/src/lib.rs
@@ -201,6 +201,8 @@ pub mod qtquickcontrols2;
 pub mod scenegraph;
 pub mod future;
 pub mod qttypes;
+#[cfg(feature = "webengine")]
+pub mod webengine;
 
 cpp! {{
     #include <qmetaobject_rust.hpp>

--- a/qmetaobject/src/webengine.rs
+++ b/qmetaobject/src/webengine.rs
@@ -1,0 +1,10 @@
+cpp! {{
+#include <QtWebEngine/QtWebEngine>
+}}
+
+/// Refer to the Qt documentation of QtWebEngine::initialize()
+pub fn initialize() {
+    cpp!(unsafe [] {
+        QtWebEngine::initialize();
+    });
+}


### PR DESCRIPTION
Add WebEngineView support and also add a simple example of usage.

Qt is quite modular. This pull request adds new dependency to the web engine module. Maybe it's worth to make its optional via #[cfg(feature = "...")] stuff. What do you think about it?