### PR TITLE
Support older Qt versions, down to 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ addons:
 
 matrix:
     include:
+        - env: QT_VERSION=56 QT_SOURCE=563
+          rust: stable
         - env: QT_VERSION=58 QT_SOURCE=58
           rust: stable
         - env: QT_VERSION=59 QT_SOURCE=593

--- a/qmetaobject/build.rs
+++ b/qmetaobject/build.rs
@@ -68,8 +68,10 @@ fn main() {
         config.flag(qt_library_path.trim());
     }
 
-    if qt_version >= Version::new(5, 14, 0) {
-        println!("cargo:rustc-cfg=qt_5_14");
+    for minor in 7..=15 {
+        if qt_version >= Version::new(5, minor, 0) {
+            println!("cargo:rustc-cfg=qt_{}_{}", 5, minor);
+        }
     }
 
     detect_qreal_size(&qt_include_path.trim());

--- a/qmetaobject/src/lib.rs
+++ b/qmetaobject/src/lib.rs
@@ -185,6 +185,7 @@ pub use qtdeclarative::*;
 pub use qmetatype::*;
 pub use connections::RustSignal;
 pub use connections::{connect, Signal, SignalInner};
+#[cfg(qt_5_7)]
 pub use qtquickcontrols2::*;
 pub use future::*;
 pub use qttypes::*;
@@ -197,6 +198,7 @@ pub mod qtdeclarative;
 pub mod qmetatype;
 pub mod qrc;
 pub mod connections;
+#[cfg(qt_5_7)]
 pub mod qtquickcontrols2;
 pub mod scenegraph;
 pub mod future;

--- a/qmetaobject/src/qtdeclarative.rs
+++ b/qmetaobject/src/qtdeclarative.rs
@@ -649,6 +649,7 @@ pub fn qml_register_singleton_instance<T: QObject + Sized + Default>(
 /// Refer to the Qt documentation for [qmlRegisterUncreatableMetaObject][qt].
 ///
 /// [qt]: https://doc.qt.io/qt-5/qqmlengine.html#qmlRegisterUncreatableMetaObject
+#[cfg(qt_5_8)]
 pub fn qml_register_enum<T: QEnum>(
     uri: &std::ffi::CStr,
     version_major: u32,
@@ -666,6 +667,7 @@ pub fn qml_register_enum<T: QEnum>(
         version_minor as "int",
         meta_object as "const QMetaObject *"
     ] {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
         qmlRegisterUncreatableMetaObject(
             *meta_object,
             uri_ptr,
@@ -674,6 +676,7 @@ pub fn qml_register_enum<T: QEnum>(
             qml_name_ptr,
             "Access to enums & flags only"
         );
+#endif
     })
 }
 

--- a/qmetaobject/src/qttypes.rs
+++ b/qmetaobject/src/qttypes.rs
@@ -124,9 +124,14 @@ impl QDate {
     pub fn get_y_m_d(&self) -> (i32, i32, i32) {
         let mut res = (0, 0, 0);
         let (ref mut y, ref mut m, ref mut d) = res;
-        cpp!(unsafe [self as "const QDate*", y as "int*", m as "int*", d as "int*"] {
+
+        // In version prior to Qt 5.7, this method was marked non-const.
+        // A #[cfg(qt_5_7)] attribute does not solve that issue, because the cpp_build crate is not
+        // smart enough not to compile the non-qualifying closure.
+        cpp!(unsafe [self as "QDate*", y as "int*", m as "int*", d as "int*"] {
             return self->getDate(y, m, d);
         });
+
         res
     }
 

--- a/qmetaobject/src/scenegraph.rs
+++ b/qmetaobject/src/scenegraph.rs
@@ -332,9 +332,11 @@ impl SGNode {
 }
 */
 
+#[cfg(qt_5_8)]
 /// Wrapper around QSGRectangleNode
 pub enum RectangleNode {}
 
+#[cfg(qt_5_8)]
 impl SGNode<RectangleNode> {
     pub fn set_color(&mut self, color: QColor) {
         let raw = self.raw;
@@ -356,8 +358,10 @@ impl SGNode<RectangleNode> {
         let item = item.get_cpp_object();
         self.raw = cpp!(unsafe [item as "QQuickItem*"] -> *mut c_void as "void*" {
             if (!item) return nullptr;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
             if (auto window = item->window())
                 return window->createRectangleNode();
+#endif
             return nullptr;
         });
     }

--- a/qmetaobject/src/scenegraph.rs
+++ b/qmetaobject/src/scenegraph.rs
@@ -15,6 +15,8 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FO
 OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
+
+#[cfg(qt_5_8)]
 use super::*;
 use std::os::raw::c_void;
 
@@ -336,18 +338,28 @@ impl SGNode {
 /// Wrapper around QSGRectangleNode
 pub enum RectangleNode {}
 
+cpp! {{
+#if QT_VERSION < QT_VERSION_CHECK(5, 8, 0)
+    struct QSGRectangleNode{};
+#endif
+}}
+
 #[cfg(qt_5_8)]
 impl SGNode<RectangleNode> {
     pub fn set_color(&mut self, color: QColor) {
         let raw = self.raw;
         cpp!(unsafe [raw as "QSGRectangleNode*", color as "QColor"] {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
             if(raw) raw->setColor(color);
+#endif
         });
     }
     pub fn set_rect(&mut self, rect: QRectF) {
         let raw = self.raw;
         cpp!(unsafe [raw as "QSGRectangleNode*", rect as "QRectF"] {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
             if (raw) raw->setRect(rect);
+#endif
         });
     }
 


### PR DESCRIPTION
Hi!

I know 5.6 is kinda old (an LTS that has known life from 2016-03-16 until 2019-03-16), but this is still what SailfishOS uses, and will probably be that for a while, until they switch to 5.12 (or hopefully something even more recent).

With the eye on keeping the difference between [my qmetaobject-sfos-rs fork](https://gitlab.com/rubdos/qmetaobject-sfos-rs) and your upstream as small as possible, I'd like to introduce `cfg` flags on all functionality between 5.6 and 5.most-recent. This should not impact upstream, but should provide me with a way more maintainable set of patches.

I hope this is alright for you folks!  If it is, I will start adding the relevant `cfg` flags to all `struct`s and methods that require them.

TODO:

- [ ] Perhaps update the readme for minimum needed Qt version?
- [ ] `git rebase --autosquash`
- [ ] Should we annotate the docs of relevant public functions with their respective Qt versions?
- [ ] Rebase my fork and test whether it works!