### PR TITLE
Implement QMetaType for QJSValue

### DIFF
--- a/qmetaobject/src/qmetatype.rs
+++ b/qmetaobject/src/qmetatype.rs
@@ -295,6 +295,8 @@ qdeclare_builtin_metatype! {isize  => 4} // That's QMetaType::LongLong
 #[cfg(target_pointer_width = "64")]
 qdeclare_builtin_metatype! {usize  => 5} // That's QMetaType::ULongLong
 
+impl QMetaType for QJSValue {}
+
 /// Internal trait used to pass or read the type in a Q_PROPERTY
 ///
 /// Don't implement this trait, implement the QMetaType trait.

--- a/qmetaobject/tests/tests.rs
+++ b/qmetaobject/tests/tests.rs
@@ -75,6 +75,7 @@ struct MyObject {
     method_out_of_line: qt_method!(fn(&self, a: QString) -> QString),
 
     prop_color: qt_property!(QColor),
+    prop_jsvalue: qt_property!(QJSValue),
 }
 
 impl MyObject {


### PR DESCRIPTION
Now QJSValue can be used in arguments of methods and properties.