### PR TITLE
Added add_image_provider method to qml engine

### DIFF
--- a/qmetaobject/src/qtdeclarative.rs
+++ b/qmetaobject/src/qtdeclarative.rs
@@ -232,6 +232,18 @@ impl QmlEngine {
             self->engine->addImportPath(path);
         })
     }
+
+    /// Add an QQuickImageProvider to the QML engine
+    ///
+    /// There currently isn't a way to construct a QQuickImageProvider in
+    /// rust so it is necessary to create a class that extend QQuickImageProvider
+    /// in cpp, then construct one and pass it to this method.
+    pub fn add_image_provider(&mut self, provider_id: QString, provider: *mut c_void) {
+        cpp!(unsafe [self as "QmlEngineHolder*", provider_id as "QString", provider as "QQmlImageProviderBase*"] {
+            self->engine->addImageProvider(provider_id, provider);
+        })
+    }
+
 }
 
 /// Bindings to a QQuickView


### PR DESCRIPTION
There currently isn't a way to construct a QQuickImageProvider in Rust but without this method there is no way to use one at all, even defined in cpp.

I've added this because I need for a project. I'd be nice to add a way to construct a QQuickImageProvider in Rust but that's beyond me.