### PR TITLE
Avoid unnecessary rebuilds

### DIFF
--- a/qttypes/build.rs
+++ b/qttypes/build.rs
@@ -127,5 +127,5 @@ fn main() {
     #[cfg(feature = "qtwebengine")]
     link_lib("WebEngine");
 
-    println!("cargo:rerun-if-changed=lib.rs");
+    println!("cargo:rerun-if-changed=src/lib.rs");
 }


### PR DESCRIPTION
The build should be re-done if src/lib.rs changes, not lib.rs
(non-existent).