### PR TITLE
Allow overriding Qt header and lib paths with environment variables in qttypes/build.rs

### DIFF
--- a/qttypes/build.rs
+++ b/qttypes/build.rs
@@ -72,8 +72,14 @@ fn main() {
             }
         }
     };
-    let qt_include_path = qmake_query("QT_INSTALL_HEADERS").unwrap();
-    let qt_library_path = qmake_query("QT_INSTALL_LIBS").unwrap();
+    let qt_include_path = match std::env::var("DEP_QT_INCLUDE_PATH") {
+        Ok(p) => p,
+        Err(_) => qmake_query("QT_INSTALL_HEADERS").unwrap(),
+    };
+    let qt_library_path = match std::env::var("DEP_QT_LIBRARY_PATH") {
+        Ok(p) => p,
+        Err(_) => qmake_query("QT_INSTALL_LIBS").unwrap(),
+    };
 
     let mut config = cpp_build::Config::new();
 


### PR DESCRIPTION
First checking whether the DEP_QT_INCLUDE_PATH and
DEP_QT_LIBRARY_PATH allows compiling against different
Qt versions than whatever qmake picks up on.

This is useful for example when cross-compiling.