### PR TITLE
Allow linking against other Qt libraries

### DIFF
--- a/qttypes/Cargo.toml
+++ b/qttypes/Cargo.toml
@@ -21,6 +21,16 @@ required = []
 qtquick = []
 # Link against QtWebEngine
 qtwebengine = []
+# Link against QtQuickControls2
+qtquickcontrols2 = []
+# Link against QtMultimedia
+qtmultimedia = []
+# Link against QtMultimediaWidgets
+qtmultimediawidgets = []
+# Link against QtSql
+qtsql = []
+# Link against QtTest
+qttest = []
 
 default = ["required"]
 

--- a/qttypes/build.rs
+++ b/qttypes/build.rs
@@ -173,6 +173,16 @@ fn main() {
     link_lib("Qml");
     #[cfg(feature = "qtwebengine")]
     link_lib("WebEngine");
+    #[cfg(feature = "qtquickcontrols2")]
+    link_lib("QuickControls2");
+    #[cfg(feature = "qtmultimedia")]
+    link_lib("Multimedia");
+    #[cfg(feature = "qtmultimediawidgets")]
+    link_lib("MultimediaWidgets");
+    #[cfg(feature = "qtsql")]
+    link_lib("Sql");
+    #[cfg(feature = "qttest")]
+    link_lib("Test");
 
     println!("cargo:rerun-if-changed=src/lib.rs");
 }


### PR DESCRIPTION
This change adds feature flags for the following Qt libraries:

 - QtQuickControls2
 - QtMultimedia
 - QtMultimediaWidgets
 - QtSql
 - QtTest

See #140 