### PR TITLE
Reduce risk of library mixing when linking against Qt on Linux

### DIFF
--- a/qttypes/build.rs
+++ b/qttypes/build.rs
@@ -150,7 +150,7 @@ fn main() {
         ""
     };
 
-    if cfg!(target_os = "macos") {
+    if cfg!(any(target_os = "macos", target_os = "linux")) {
         println!("cargo:rustc-cdylib-link-arg=-Wl,-rpath,{}", qt_library_path.trim());
     }
 

--- a/qttypes/build.rs
+++ b/qttypes/build.rs
@@ -150,7 +150,7 @@ fn main() {
         ""
     };
 
-    if cfg!(any(target_os = "macos", target_os = "linux")) {
+    if std::env::var("CARGO_CFG_TARGET_FAMILY").as_ref().map(|s| s.as_ref()) == Ok("unix") {
         println!("cargo:rustc-cdylib-link-arg=-Wl,-rpath,{}", qt_library_path.trim());
     }
 


### PR DESCRIPTION
Similar to macOS, also use rpath on Linux, to encode the location of
where we found Qt.

cc sixtyfpsui/sixtyfps#232