### PR TITLE
Introduce prelude

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Presentation Blog Post: https://woboq.com/blog/qmetaobject-from-rust.html
 
 ```rust
 use cstr::cstr;
-use qmetaobject::*;
+use qmetaobject::prelude::*;
 
 // The `QObject` custom derive macro allows to expose a class to Qt and QML
 #[derive(QObject, Default)]

--- a/examples/graph/src/main.rs
+++ b/examples/graph/src/main.rs
@@ -4,8 +4,8 @@
 use cpp::cpp;
 use cstr::cstr;
 
+use qmetaobject::prelude::*;
 use qmetaobject::scenegraph::*;
-use qmetaobject::*;
 
 mod nodes;
 

--- a/examples/qmlextensionplugins/src/lib.rs
+++ b/examples/qmlextensionplugins/src/lib.rs
@@ -5,7 +5,7 @@ use std::thread::JoinHandle;
 use chrono::Timelike;
 use cstr::cstr;
 
-use qmetaobject::*;
+use qmetaobject::prelude::*;
 
 #[derive(Default)]
 struct AbortCondVar {

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -1,6 +1,6 @@
 use cstr::cstr;
 
-use qmetaobject::*;
+use qmetaobject::prelude::*;
 
 mod implementation;
 

--- a/examples/webengine/src/main.rs
+++ b/examples/webengine/src/main.rs
@@ -1,4 +1,5 @@
-use qmetaobject::*;
+use qmetaobject::prelude::*;
+use qmetaobject::webengine;
 
 qrc!(my_resource,
     "webengine" {

--- a/qmetaobject/src/lib.rs
+++ b/qmetaobject/src/lib.rs
@@ -22,7 +22,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
     ```
     use cstr::cstr;
-    use qmetaobject::*;
+    use qmetaobject::prelude::*;
 
     // The `QObject` custom derive macro allows to expose a class to Qt and QML
     #[derive(QObject,Default)]
@@ -114,7 +114,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     This can be done like so:
 
     ```
-    use qmetaobject::*;
+    use qmetaobject::prelude::*;
     # use std::cell::RefCell;
 
     #[derive(QObject, Default)]
@@ -124,7 +124,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         result_changed: qt_signal!(),
         recompute_result: qt_method!(fn recompute_result(&self, name: String) {
             let qptr = QPointer::from(&*self);
-            let set_value = queued_callback(move |val: QString| {
+            let set_value = qmetaobject::queued_callback(move |val: QString| {
                 qptr.as_pinned().map(|this| {
                     this.borrow_mut().result = val;
                     this.borrow().result_changed();
@@ -139,7 +139,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     }
     # let obj = RefCell::new(MyAsyncObject::default());
     # let mut engine = QmlEngine::new();
-    # unsafe { connect(
+    # unsafe { qmetaobject::connect(
     #     QObject::cpp_construct(&obj),
     #     obj.borrow().result_changed.to_cpp_representation(&*obj.borrow()),
     #     || engine.quit()
@@ -208,6 +208,16 @@ pub mod scenegraph;
 pub mod tablemodel;
 #[cfg(feature = "webengine")]
 pub mod webengine;
+
+/// Module intended for glob import.
+pub mod prelude {
+    pub use crate::{
+        qml_register_type, qrc, qt_base_class, qt_method, qt_plugin, qt_property, qt_signal,
+        QAbstractListModel, QByteArray, QColor, QDate, QDateTime, QModelIndex, QObject, QObjectBox,
+        QPointer, QQmlExtensionPlugin, QQuickItem, QQuickView, QRectF, QString, QTime, QVariant,
+        QmlEngine,
+    };
+}
 
 cpp! {{
     #include <qmetaobject_rust.hpp>

--- a/qmetaobject/src/lib.rs
+++ b/qmetaobject/src/lib.rs
@@ -171,7 +171,7 @@ pub use qmetaobject_impl::{QEnum6 as QEnum, QGadget6 as QGadget, QObject6 as QOb
 pub use lazy_static::lazy_static;
 #[doc(hidden)]
 #[macro_export]
-macro_rules! qmetaobject_lazy_static { ($($t:tt)*) => { lazy_static!($($t)*) } }
+macro_rules! qmetaobject_lazy_static { ($($t:tt)*) => { $crate::lazy_static!($($t)*) } }
 
 use std::cell::{RefCell, RefMut};
 use std::ffi::{CStr, CString};

--- a/qmetaobject_impl/src/qobject_impl.rs
+++ b/qmetaobject_impl/src/qobject_impl.rs
@@ -614,7 +614,7 @@ pub fn generate(input: TokenStream, is_qobject: bool, qt_version: QtVersion) -> 
             quote!({
                 #crate_::qmetaobject_lazy_static! {
                     static ref ARRAY : [usize; #len] = [
-                        #(qmetatype_interface_ptr::<#meta_types>(
+                        #(#crate_::qmetatype_interface_ptr::<#meta_types>(
                             &::std::ffi::CString::new(stringify!(#meta_types)).unwrap()) as usize),*
                     ];
                 }


### PR DESCRIPTION
Fixes #83, with the motto "a semi-good prelude is better than none".

They only "breaking" change (when changing `qmetaobject::*` for `qmetaobject::prelude::*`) would be that I've left out `connect`, since that's quite a generic name. I had to change this at one single place in a doc comment.

I'm still going to try whether I can yeet `lazy_static` too, give me a second here :-)