### PR TITLE
derive(SimpleListItem) should not require QVariant and QByteArray to be in scope

### DIFF
--- a/qmetaobject_impl/src/simplelistitem_impl.rs
+++ b/qmetaobject_impl/src/simplelistitem_impl.rs
@@ -47,7 +47,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
         .enumerate()
         .map(|(i, ref ident)| {
             let i = i as i32;
-            quote! { #i => QMetaType::to_qvariant(&self.#ident), }
+            quote! { #i => #crate_::QMetaType::to_qvariant(&self.#ident), }
         })
         .collect::<Vec<_>>();
 
@@ -56,14 +56,14 @@ pub fn derive(input: TokenStream) -> TokenStream {
 
     quote!(
         impl #impl_generics #crate_::listmodel::SimpleListItem for #name #ty_generics #where_clause {
-            fn get(&self, idx : i32) -> QVariant {
+            fn get(&self, idx : i32) -> #crate_::QVariant {
                 match idx {
                     #(#arms)*
-                    _ => QVariant::default()
+                    _ => #crate_::QVariant::default()
                 }
             }
-            fn names() -> Vec<QByteArray> {
-                vec![ #(QByteArray::from(stringify!(#values))),* ]
+            fn names() -> Vec<#crate_::QByteArray> {
+                vec![ #(#crate_::QByteArray::from(stringify!(#values))),* ]
             }
         }
     ).into()


### PR DESCRIPTION
Addresses https://github.com/woboq/qmetaobject-rs/issues/156

> If one does not use `use qmetaobject::*` or `use qmetaobject::{QVariant, QByteArray}`, `#[derive(qmetaobject::SimpleListItem)]` will fail to compile. It requires `QVariant` and `QByteArray` to be in scope.

This PR references them by their fully qualified name