### PR TITLE
README: Rewrite the headline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # QMetaObject crate for Rust
 
-The qmetaobject crate is a crate which is used to expose rust object to Qt and QML.
-
 [![Appveyor Build status](https://ci.appveyor.com/api/projects/status/8l5te3wlj2ie4njc/branch/master?svg=true)](https://ci.appveyor.com/project/ogoffart/qmetaobject-rs/branch/master)
 [![Crates.io](https://img.shields.io/crates/v/qmetaobject.svg)](https://crates.io/crates/qmetaobject)
 [![Documentation](https://docs.rs/qmetaobject/badge.svg)](https://docs.rs/qmetaobject/)
+
+A framework empowering everyone to create Qt/QML applications with Rust.
+It does so by building `QMetaObject`s at compile time, registering QML types (optionally via exposing `QQmlExtensionPlugin`s) and providing native wrappers.
 
 ## Objectives
 


### PR DESCRIPTION
The %crate% is a crate which is a crate that is used...

Meh! No one reads such long headlines. And that is not even technically
correct, since qmetaobjec-rs is actually a bunch of crates under cargo
workspace umbrella.

New headline shamelessly mimics Rust because they have spent really good
amount of effort to make it short and attractive.

However, personally, I don't like the Rust headline that much. It says:

> A language empowering everyone
> **to build** reliable and efficient software.

Creating an app is not just about building it. But on the other hand,
Cargo is all about building Rust code. Further deployment process and
execution environment is up to a developer, as far as Rust is
concerned. I guess it's fine for them; but Qt's focus is a bit broader.