### PR TITLE
Yet another cleanup round

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Documentation](https://docs.rs/qmetaobject/badge.svg)](https://docs.rs/qmetaobject/)
 
 A framework empowering everyone to create Qt/QML applications with Rust.
-It does so by building `QMetaObject`s at compile time, registering QML types (optionally via exposing `QQmlExtensionPlugin`s) and providing native wrappers.
+It does so by building `QMetaObject`s at compile time, registering QML types (optionally via exposing `QQmlExtensionPlugin`s) and providing idiomatic wrappers.
 
 ## Objectives
 

--- a/examples/graph/src/main.qml
+++ b/examples/graph/src/main.qml
@@ -65,8 +65,9 @@ Item {
         }
 
         Component.onCompleted: {
-            for (var i=0; i<100; ++i)
+            for (let i = 0; i < 100; ++i) {
                 appendSample(newSample(i));
+            }
         }
 
         property int offset: 100

--- a/examples/graph/src/main.rs
+++ b/examples/graph/src/main.rs
@@ -91,9 +91,10 @@ impl QQuickItem for Graph {
 }
 
 fn main() {
+    nodes::init_resources();
     qml_register_type::<Graph>(cstr!("Graph"), 1, 0, cstr!("Graph"));
     let mut view = QQuickView::new();
-    view.set_source(format!("{}/src/main.qml", env!("CARGO_MANIFEST_DIR")).into());
+    view.set_source("qrc:/qml/main.qml".into());
     view.show();
     view.engine().exec();
 }

--- a/examples/graph/src/nodes.rs
+++ b/examples/graph/src/nodes.rs
@@ -5,13 +5,15 @@ use qmetaobject::{qrc, QQuickItem};
 use qttypes::{QColor, QRectF};
 
 qrc! {
-    init_resource,
+    pub init_resources,
     "scenegraph/graph" {
-//        "main.qml",
         "shaders/noisy.vsh",
         "shaders/noisy.fsh",
         "shaders/line.vsh",
         "shaders/line.fsh",
+    },
+    "src" as "qml" {
+        "main.qml"
     }
 }
 
@@ -28,7 +30,6 @@ cpp! {{
 pub enum NoisyNode {}
 
 pub fn create_noisy_node(s: &mut SGNode<NoisyNode>, ctx: &dyn QQuickItem) {
-    init_resource();
     let item_ptr = ctx.get_cpp_object();
     cpp!(unsafe [s as "NoisyNode**", item_ptr as "QQuickItem*"] {
         if (!*s && item_ptr) {
@@ -55,7 +56,6 @@ pub fn update_grid_node(s: &mut SGNode<GridNode>, rect: QRectF) {
 
 pub enum LineNode {}
 pub fn create_line_node(s: &mut SGNode<LineNode>, size: f32, spread: f32, color: QColor) {
-    init_resource();
     cpp!(unsafe [s as "LineNode**", size as "float", spread as "float", color as "QColor"] {
         if (!*s) *s = new LineNode(size, spread, color);
     });

--- a/examples/graph/src/nodes.rs
+++ b/examples/graph/src/nodes.rs
@@ -19,10 +19,10 @@ qrc! {
 // However, there is quite some API to expose.
 
 cpp! {{
-#include "src/linenode.cpp"
-#include "src/noisynode.cpp"
-#include "src/gridnode.cpp"
-#include <QtQuick/QQuickItem>
+    #include "src/linenode.cpp"
+    #include "src/noisynode.cpp"
+    #include "src/gridnode.cpp"
+    #include <QtQuick/QQuickItem>
 }}
 
 pub enum NoisyNode {}

--- a/qmetaobject/src/lib.rs
+++ b/qmetaobject/src/lib.rs
@@ -953,6 +953,7 @@ pub const USER_ROLE: i32 = 0x0100;
 /// # Input
 ///
 /// The macro accepts the following formal grammar in pseudo [rust macro syntax][macro-doc]:
+///
 /// ```txt
 /// macro call ::= qrc!( $f:Function $( $r:Recource ),* )
 /// Function   ::= $v:vis $name:ident
@@ -979,7 +980,7 @@ pub const USER_ROLE: i32 = 0x0100;
 ///  - `$base_dir:physical`: optional path to base directory on local file
 ///    system, separated from the prefix by the `as` keyword.
 ///    By default, base directory is the cargo project's root - directory with
-///    Cargo.toml, a.k.a. [`$CARGO_MANIFEST_DIR`][].
+///    _Cargo.toml_, a.k.a. [`$CARGO_MANIFEST_DIR`][].
 ///    (Custom extention which does not interfere with qrc format,
 ///    but merely resolves physical path of files in this resource relative
 ///    to the base directory, and helps keeping both project's root directory
@@ -1013,6 +1014,7 @@ pub const USER_ROLE: i32 = 0x0100;
 /// # Example
 ///
 /// Consider this project files structure:
+///
 /// ```text
 /// .
 /// ├── Cargo.toml
@@ -1023,7 +1025,9 @@ pub const USER_ROLE: i32 = 0x0100;
 /// └── src
 ///     └── main.rs
 /// ```
+///
 /// then the following Rust code:
+///
 /// ```
 /// use qmetaobject::qrc;
 /// # // For maintainers: this is actually tested against real files.
@@ -1068,7 +1072,9 @@ pub const USER_ROLE: i32 = 0x0100;
 /// use_resource("qrc:/foo2/baz/Foo.qml");
 /// # }
 /// ```
+///
 /// corresponds to the .qrc (`tests/qml/qml.qrc`) file:
+///
 /// ```xml
 /// <RCC>
 ///     <qresource prefix="/foo">

--- a/qmetaobject/src/listmodel.rs
+++ b/qmetaobject/src/listmodel.rs
@@ -130,63 +130,61 @@ pub trait QAbstractListModel: QObject {
 }
 
 cpp! {{
-#include <qmetaobject_rust.hpp>
-#include <QtCore/QAbstractListModel>
-}}
+    #include <qmetaobject_rust.hpp>
+    #include <QtCore/QAbstractListModel>
 
-cpp! {{
-struct Rust_QAbstractListModel : RustObject<QAbstractListModel> {
+    struct Rust_QAbstractListModel : RustObject<QAbstractListModel> {
 
-    using QAbstractListModel::beginInsertRows;
-    using QAbstractListModel::endInsertRows;
-    using QAbstractListModel::beginRemoveRows;
-    using QAbstractListModel::endRemoveRows;
-    using QAbstractListModel::beginResetModel;
-    using QAbstractListModel::endResetModel;
+        using QAbstractListModel::beginInsertRows;
+        using QAbstractListModel::endInsertRows;
+        using QAbstractListModel::beginRemoveRows;
+        using QAbstractListModel::endRemoveRows;
+        using QAbstractListModel::beginResetModel;
+        using QAbstractListModel::endResetModel;
 
-    int rowCount(const QModelIndex & = QModelIndex()) const override {
-        return rust!(Rust_QAbstractListModel_rowCount[rust_object : QObjectPinned<dyn QAbstractListModel> as "TraitObject"]
-                -> i32 as "int" {
-            rust_object.borrow().row_count()
-        });
-    }
+        int rowCount(const QModelIndex & = QModelIndex()) const override {
+            return rust!(Rust_QAbstractListModel_rowCount[rust_object : QObjectPinned<dyn QAbstractListModel> as "TraitObject"]
+                    -> i32 as "int" {
+                rust_object.borrow().row_count()
+            });
+        }
 
-    //int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+        //int columnCount(const QModelIndex &parent = QModelIndex()) const override;
 
-    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override {
-        return rust!(Rust_QAbstractListModel_data[rust_object : QObjectPinned<dyn QAbstractListModel> as "TraitObject",
-                index : QModelIndex as "QModelIndex", role : i32 as "int"] -> QVariant as "QVariant" {
-            rust_object.borrow().data(index, role)
-        });
-    }
+        QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override {
+            return rust!(Rust_QAbstractListModel_data[rust_object : QObjectPinned<dyn QAbstractListModel> as "TraitObject",
+                    index : QModelIndex as "QModelIndex", role : i32 as "int"] -> QVariant as "QVariant" {
+                rust_object.borrow().data(index, role)
+            });
+        }
 
-    bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override {
-        return rust!(Rust_QAbstractListModel_setData[rust_object : QObjectPinned<dyn QAbstractListModel> as "TraitObject",
-                index : QModelIndex as "QModelIndex", value : QVariant as "QVariant", role : i32 as "int"]
-                -> bool as "bool" {
-            rust_object.borrow_mut().set_data(index, &value, role)
-        });
-    }
+        bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override {
+            return rust!(Rust_QAbstractListModel_setData[rust_object : QObjectPinned<dyn QAbstractListModel> as "TraitObject",
+                    index : QModelIndex as "QModelIndex", value : QVariant as "QVariant", role : i32 as "int"]
+                    -> bool as "bool" {
+                rust_object.borrow_mut().set_data(index, &value, role)
+            });
+        }
 
-    //Qt::ItemFlags flags(const QModelIndex &index) const override;
+        //Qt::ItemFlags flags(const QModelIndex &index) const override;
 
-    //QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+        //QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
 
-    QHash<int, QByteArray> roleNames() const override {
-        QHash<int, QByteArray> base = QAbstractListModel::roleNames();
-        rust!(Rust_QAbstractListModel_roleNames[rust_object : QObjectPinned<dyn QAbstractListModel> as "TraitObject",
-                base: *mut c_void as "QHash<int, QByteArray>&"] {
-            for (key, val) in rust_object.borrow().role_names().iter() {
-                add_to_hash(base, *key, val.clone());
-            }
-        });
-        return base;
-    }
+        QHash<int, QByteArray> roleNames() const override {
+            QHash<int, QByteArray> base = QAbstractListModel::roleNames();
+            rust!(Rust_QAbstractListModel_roleNames[rust_object : QObjectPinned<dyn QAbstractListModel> as "TraitObject",
+                    base: *mut c_void as "QHash<int, QByteArray>&"] {
+                for (key, val) in rust_object.borrow().role_names().iter() {
+                    add_to_hash(base, *key, val.clone());
+                }
+            });
+            return base;
+        }
 
-    //QModelIndex index(int row, int column, const QModelIndex &parent) const override;
+        //QModelIndex index(int row, int column, const QModelIndex &parent) const override;
 
-    //QModelIndex parent(const QModelIndex &child) const override;
-};
+        //QModelIndex parent(const QModelIndex &child) const override;
+    };
 }}
 
 /// A trait used in SimpleListModel.

--- a/qmetaobject/src/qrc.rs
+++ b/qmetaobject/src/qrc.rs
@@ -18,8 +18,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 use cpp::cpp;
 
 cpp! {{
-Q_CORE_EXPORT bool qRegisterResourceData(int, const unsigned char *,
-                                         const unsigned char *, const unsigned char *);
+    Q_CORE_EXPORT bool qRegisterResourceData(int, const unsigned char *,
+                                             const unsigned char *, const unsigned char *);
 }}
 
 /// Internal function used from qrc procedural macro.

--- a/qmetaobject/src/scenegraph.rs
+++ b/qmetaobject/src/scenegraph.rs
@@ -62,12 +62,12 @@ impl<T> Drop for SGNode<T> {
 pub enum ContainerNode {}
 
 cpp! {{
-struct ContainerNode : QSGNode {
-    quint64 type_id = 0;
-    std::size_t size = 0; // -1 for static
-    quint64 mask = 0; // one bit for every child, if it is set, or not
-    ContainerNode(quint64 type_id, std::size_t size) : type_id(type_id), size(size) {}
-};
+    struct ContainerNode : QSGNode {
+        quint64 type_id = 0;
+        std::size_t size = 0; // -1 for static
+        quint64 mask = 0; // one bit for every child, if it is set, or not
+        ContainerNode(quint64 type_id, std::size_t size) : type_id(type_id), size(size) {}
+    };
 }}
 
 /// Represent a tuple of `Fn(`[`SGNode`]`<...>) -> SGNode<...>)`,
@@ -445,7 +445,7 @@ struct SGGeometryNode {
     node : SGNode,
 }
 
-cpp!{{
+cpp! {{
 struct RustGeometryNode : QSGGeometryNode {
     QSGGeometry geo;
     RustGeometryNode(const QSGGeometry::AttributeSet &attribs, int vertexCount)

--- a/qmetaobject/src/scenegraph.rs
+++ b/qmetaobject/src/scenegraph.rs
@@ -58,7 +58,7 @@ impl<T> Drop for SGNode<T> {
 
 /// Tag to be used in SGNode. SGNode<ContainerNode> is a node that simply contains other node.
 /// Either all the node have the same type, but the number of nodes is not known at compile time,
-/// or the child node can have different type, but the amont of nodes is known at compile time
+/// or the child node can have different type, but the amount of nodes is known at compile time
 pub enum ContainerNode {}
 
 cpp! {{
@@ -70,7 +70,8 @@ struct ContainerNode : QSGNode {
 };
 }}
 
-/// Represent a tuple of Fn(SGNode<...>)->SGNode<...>), for SGNode<ContainerNode>::update_static
+/// Represent a tuple of `Fn(`[`SGNode`]`<...>) -> SGNode<...>)`,
+/// for [`SGNode<ContainerNode>::update_static`].
 ///
 /// Do not reimplement
 #[cfg_attr(feature = "cargo-clippy", allow(clippy::len_without_is_empty))]
@@ -81,19 +82,22 @@ pub trait UpdateNodeFnTuple<T> {
 
 // Implementation for tuple of different sizes
 macro_rules! declare_UpdateNodeFnTuple {
-    (@continue $T:ident : $A:ident : $N:tt $($tail:tt)+) => { declare_UpdateNodeFnTuple![$($tail)*]; };
+    (@continue $T:ident : $A:ident : $N:tt $( $tail:tt )+) => { declare_UpdateNodeFnTuple![$( $tail )*]; };
     (@continue $T:ident : $A:ident : $N:tt) => {};
-    ($($T:ident : $A:ident : $N:tt)+) => {
-        impl<$($A, $T : Fn(SGNode<$A>)->SGNode<$A>),*> UpdateNodeFnTuple<($($A,)*)> for ($($T,)*)
+    ($( $T:ident : $A:ident : $N:tt )+) => {
+        impl<$( $A, $T: Fn(SGNode<$A>) -> SGNode<$A> ),*> UpdateNodeFnTuple<($( $A, )*)> for ($( $T, )*)
         {
-            fn len(&self) -> u64 { ($($N,)* ).0 + 1 }
-            unsafe fn update_fn(&self, i : u64, n : *mut c_void) -> *mut c_void {
-                match i { $($N => (self.$N)( SGNode::<_>::from_raw(n) ).into_raw(), )*
+            fn len(&self) -> u64 { ($( $N, )* ).0 + 1 }
+            unsafe fn update_fn(&self, i: u64, n: *mut c_void) -> *mut c_void {
+                match i {
+                    $(
+                        $N => (self.$N)( SGNode::<_>::from_raw(n) ).into_raw(),
+                    )*
                     _ => panic!("Out of range") }
             }
         }
 
-        declare_UpdateNodeFnTuple![@continue $($T : $A : $N)*];
+        declare_UpdateNodeFnTuple![@continue $( $T : $A : $N )*];
     }
 }
 declare_UpdateNodeFnTuple![T9:A9:9 T8:A8:8 T7:A7:7 T6:A6:6 T5:A5:5 T4:A4:4 T3:A3:3 T2:A2:2 T1:A1:1 T0:A0:0];
@@ -415,8 +419,7 @@ impl SGNode<TransformNode> {
         }
         let raw = self.raw;
         let sub = unsafe {
-            SGNode::<ContainerNode>::from_raw(cpp!([raw as "QSGNode*"]
-                    -> *mut c_void as "QSGNode*" {
+            SGNode::<ContainerNode>::from_raw(cpp!([raw as "QSGNode*"] -> *mut c_void as "QSGNode*" {
                 auto n = raw->firstChild();
                 if (n)
                     n->setFlag(QSGNode::OwnedByParent, false); // now we own it;

--- a/qmetaobject/src/tablemodel.rs
+++ b/qmetaobject/src/tablemodel.rs
@@ -145,70 +145,68 @@ pub trait QAbstractTableModel: QObject {
 }
 
 cpp! {{
-#include <qmetaobject_rust.hpp>
-#include <QtCore/QAbstractTableModel>
-}}
+    #include <qmetaobject_rust.hpp>
+    #include <QtCore/QAbstractTableModel>
 
-cpp! {{
-struct Rust_QAbstractTableModel : RustObject<QAbstractTableModel> {
+    struct Rust_QAbstractTableModel : RustObject<QAbstractTableModel> {
 
-    using QAbstractTableModel::beginInsertRows;
-    using QAbstractTableModel::endInsertRows;
-    using QAbstractTableModel::beginInsertColumns;
-    using QAbstractTableModel::endInsertColumns;
-    using QAbstractTableModel::beginRemoveRows;
-    using QAbstractTableModel::endRemoveRows;
-    using QAbstractTableModel::beginRemoveColumns;
-    using QAbstractTableModel::endRemoveColumns;
-    using QAbstractTableModel::beginResetModel;
-    using QAbstractTableModel::endResetModel;
+        using QAbstractTableModel::beginInsertRows;
+        using QAbstractTableModel::endInsertRows;
+        using QAbstractTableModel::beginInsertColumns;
+        using QAbstractTableModel::endInsertColumns;
+        using QAbstractTableModel::beginRemoveRows;
+        using QAbstractTableModel::endRemoveRows;
+        using QAbstractTableModel::beginRemoveColumns;
+        using QAbstractTableModel::endRemoveColumns;
+        using QAbstractTableModel::beginResetModel;
+        using QAbstractTableModel::endResetModel;
 
-    int rowCount(const QModelIndex & = QModelIndex()) const override {
-        return rust!(Rust_QAbstractTableModel_rowCount[rust_object : QObjectPinned<dyn QAbstractTableModel> as "TraitObject"]
-                -> i32 as "int" {
-            rust_object.borrow().row_count()
-        });
-    }
+        int rowCount(const QModelIndex & = QModelIndex()) const override {
+            return rust!(Rust_QAbstractTableModel_rowCount[rust_object : QObjectPinned<dyn QAbstractTableModel> as "TraitObject"]
+                    -> i32 as "int" {
+                rust_object.borrow().row_count()
+            });
+        }
 
-    int columnCount(const QModelIndex & = QModelIndex()) const override {
-        return rust!(Rust_QAbstractTableModel_columnCount[rust_object : QObjectPinned<dyn QAbstractTableModel> as "TraitObject"]
-                -> i32 as "int" {
-            rust_object.borrow().column_count()
-        });
-    }
+        int columnCount(const QModelIndex & = QModelIndex()) const override {
+            return rust!(Rust_QAbstractTableModel_columnCount[rust_object : QObjectPinned<dyn QAbstractTableModel> as "TraitObject"]
+                    -> i32 as "int" {
+                rust_object.borrow().column_count()
+            });
+        }
 
-    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override {
-        return rust!(Rust_QAbstractTableModel_data[rust_object : QObjectPinned<dyn QAbstractTableModel> as "TraitObject",
-                index : QModelIndex as "QModelIndex", role : i32 as "int"] -> QVariant as "QVariant" {
-            rust_object.borrow().data(index, role)
-        });
-    }
+        QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override {
+            return rust!(Rust_QAbstractTableModel_data[rust_object : QObjectPinned<dyn QAbstractTableModel> as "TraitObject",
+                    index : QModelIndex as "QModelIndex", role : i32 as "int"] -> QVariant as "QVariant" {
+                rust_object.borrow().data(index, role)
+            });
+        }
 
-    bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override {
-        return rust!(Rust_QAbstractTableModel_setData[rust_object : QObjectPinned<dyn QAbstractTableModel> as "TraitObject",
-                index : QModelIndex as "QModelIndex", value : QVariant as "QVariant", role : i32 as "int"]
-                -> bool as "bool" {
-            rust_object.borrow_mut().set_data(index, &value, role)
-        });
-    }
+        bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override {
+            return rust!(Rust_QAbstractTableModel_setData[rust_object : QObjectPinned<dyn QAbstractTableModel> as "TraitObject",
+                    index : QModelIndex as "QModelIndex", value : QVariant as "QVariant", role : i32 as "int"]
+                    -> bool as "bool" {
+                rust_object.borrow_mut().set_data(index, &value, role)
+            });
+        }
 
-    //Qt::ItemFlags flags(const QModelIndex &index) const override;
+        //Qt::ItemFlags flags(const QModelIndex &index) const override;
 
-    //QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+        //QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
 
-    QHash<int, QByteArray> roleNames() const override {
-        QHash<int, QByteArray> base = QAbstractTableModel::roleNames();
-        rust!(Rust_QAbstractTableModel_roleNames[rust_object : QObjectPinned<dyn QAbstractTableModel> as "TraitObject",
-                base: *mut c_void as "QHash<int, QByteArray>&"] {
-            for (key, val) in rust_object.borrow().role_names().iter() {
-                add_to_hash(base, *key, val.clone());
-            }
-        });
-        return base;
-    }
+        QHash<int, QByteArray> roleNames() const override {
+            QHash<int, QByteArray> base = QAbstractTableModel::roleNames();
+            rust!(Rust_QAbstractTableModel_roleNames[rust_object : QObjectPinned<dyn QAbstractTableModel> as "TraitObject",
+                    base: *mut c_void as "QHash<int, QByteArray>&"] {
+                for (key, val) in rust_object.borrow().role_names().iter() {
+                    add_to_hash(base, *key, val.clone());
+                }
+            });
+            return base;
+        }
 
-    //QModelIndex index(int row, int column, const QModelIndex &parent) const override;
+        //QModelIndex index(int row, int column, const QModelIndex &parent) const override;
 
-    //QModelIndex parent(const QModelIndex &child) const override;
-};
+        //QModelIndex parent(const QModelIndex &child) const override;
+    };
 }}

--- a/qmetaobject/src/webengine.rs
+++ b/qmetaobject/src/webengine.rs
@@ -1,7 +1,7 @@
 use cpp::cpp;
 
 cpp! {{
-#include <QtWebEngine/QtWebEngine>
+    #include <QtWebEngine/QtWebEngine>
 }}
 
 /// Refer to the Qt documentation of QtWebEngine::initialize()

--- a/qmetaobject/tests/tests.rs
+++ b/qmetaobject/tests/tests.rs
@@ -595,7 +595,7 @@ fn connect_cpp_signal() {
     let obj_ptr = unsafe { QObjectPinned::new(&f).get_or_create_cpp_object() };
     let mut result = None;
     let con = unsafe {
-        connect(obj_ptr, QObject::object_name_changed_signal(), |name: &QString| {
+        connect(obj_ptr, <dyn QObject>::object_name_changed_signal(), |name: &QString| {
             result = Some(name.clone());
         })
     };

--- a/qmetaobject_impl/src/lib.rs
+++ b/qmetaobject_impl/src/lib.rs
@@ -89,7 +89,7 @@ pub fn qenum_impl6(input: TokenStream) -> TokenStream {
     qobject_impl::generate_enum(input, 6)
 }
 
-/// Implementation of the qmetaobject::qrc! macro
+// Implementation of the qmetaobject::qrc! macro
 #[proc_macro]
 pub fn qrc_internal(input: TokenStream) -> TokenStream {
     qrc_impl::process_qrc(input)

--- a/qttypes/src/lib.rs
+++ b/qttypes/src/lib.rs
@@ -151,11 +151,11 @@ macro_rules! cpp_class {
 
 cpp! {{
     #include <QtCore/QByteArray>
-    #include <QtCore/QString>
     #include <QtCore/QDateTime>
-    #include <QtCore/QVariant>
     #include <QtCore/QModelIndex>
+    #include <QtCore/QString>
     #include <QtCore/QUrl>
+    #include <QtCore/QVariant>
 
     #include <QtGui/QImage>
     #include <QtGui/QPixmap>


### PR DESCRIPTION
A bunch of clean-ups including but not limited to code style cosmits. Not much, but it's been lying around in my stash and bugging me out for too long.

* Fix bare_trait_objects deprecation warning
* example(graph): Move main.qml into qrc
* cosmit: Use modern ECMAScript `let` instead of var
* cosmit: Unify cpp! {{ ... }} macro style
* Wrap test code in `#[cfg(test)] mod tests` boilerplate
* cosmit: Prettify scenegraph macro code
* cosmit: Add visual spacing to qrc! docs
