### PR TITLE
Remove QT_SELECT environment when running qmake

### DIFF
--- a/qttypes/build.rs
+++ b/qttypes/build.rs
@@ -24,7 +24,7 @@ use std::process::Command;
 fn qmake_query(var: &str) -> Result<String, std::io::Error> {
     let qmake = std::env::var("QMAKE").unwrap_or("qmake".to_string());
     Ok(String::from_utf8(
-        Command::new(qmake).env("QT_SELECT", "qt5").args(&["-query", var]).output()?.stdout,
+        Command::new(qmake).args(&["-query", var]).output()?.stdout,
     )
     .expect("UTF-8 conversion failed"))
 }


### PR DESCRIPTION
That's something that does not exists (anymore).
Even qtchooser repository was removed.

R.I.P. https://code.qt.io/cgit/qt/qtchooser.git

---

I searched high and low, and did not find any traces of QT_SELECT in qt repositories (X11 clipboard selection shows up, but  it's completely irrelevant). However, there are old answers on StackOverflow that suggest using this env variable. Alternative syntax was `qmake -qt=qt5 ...`, but it is an `***Unknown option` at this point (Qt 5.15.2, Qt 6.1.2).

So, I concluded that it's a deleted piece of functionality, no longer usable, and not needed in our code base.