### PR TITLE
Add wrappers around public static getters & setters of QCoreApplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Tutorial on adding Rust wrappers #171.
+- QCoreApplication: wrappers around public static getters & setters #185.
 
 ### Deprecated
 - Rename QObjectDescription in favor of its new name RustQObjectDescriptor #172.

--- a/qmetaobject/src/lib.rs
+++ b/qmetaobject/src/lib.rs
@@ -195,6 +195,7 @@ pub use qttypes::*;
 pub use tablemodel::*;
 
 pub mod connections;
+pub mod qtcore;
 pub mod future;
 pub mod itemmodel;
 pub mod listmodel;

--- a/qmetaobject/src/qmetatype.rs
+++ b/qmetaobject/src/qmetatype.rs
@@ -138,7 +138,7 @@ fn register_metatype_common<T: QMetaType>(
         let deleter_fn: extern "C" fn(v: *mut T) = deleter_fn;
 
         #[cfg(qt_6_0)]
-        let deleter_fn: *const c_void = core::ptr::null();
+        let deleter_fn: *const c_void = ::core::ptr::null();
 
         #[cfg(not(qt_6_0))]
         extern "C" fn creator_fn<T: Default + Clone>(c: *const T) -> *const T {
@@ -240,7 +240,7 @@ fn register_metatype_common<T: QMetaType>(
                 alignment: u16,
                 size: u32,
                 flags: u32,
-                typeId: core::sync::atomic::AtomicI32,
+                typeId: ::core::sync::atomic::AtomicI32,
                 metaObjectFn: extern "C" fn(*const QMetaTypeInterface)-> *const QMetaObject,
                 name: *const c_char,
                 defaultCtr:  extern "C" fn(*const QMetaTypeInterface, *mut c_void),

--- a/qmetaobject/src/qtcore/core_application.rs
+++ b/qmetaobject/src/qtcore/core_application.rs
@@ -1,0 +1,132 @@
+/* Copyright (C) 2018 Olivier Goffart <ogoffart@woboq.com>
+   Copyright (C) 2021 ivan tkachenko a.k.a. ratijas <me@ratijas.tk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+//! Wrappers around [`QtCore/QCoreApplication`][qt] header.
+//!
+//! [qt]: https://doc.qt.io/qt-5/qcoreapplication.html
+
+use cpp::cpp;
+
+use crate::*;
+
+cpp! {{
+    #include <QtCore/QCoreApplication>
+}}
+
+/// Wrapper around [`QCoreApplication`][qt] class.
+///
+/// # Wrapper-specific
+///
+/// Currently it is uncreatible, non-obtainable, and exists purely as a
+/// namespace for public static members (associated functions in Rust).
+///
+/// [qt]: https://doc.qt.io/qt-5/qcoreapplication.html
+pub struct QCoreApplication {
+    // Private field makes this dummy struct uncreatable by user. Since
+    // there's no way to obtain an instance of it, we won't have to worry
+    // about layout compatibility and stuff.
+    _private: (),
+}
+
+impl QCoreApplication {
+    /// Wrapper around [`QString applicationName()`][qt] static method.
+    ///
+    /// [qt]: https://doc.qt.io/qt-5/qcoreapplication.html#applicationName-prop
+    pub fn application_name() -> QString {
+        cpp!(unsafe [] -> QString as "QString" {
+            return QCoreApplication::applicationName();
+        })
+    }
+
+    /// Wrapper around [`void setApplicationName(const QString &application)`][qt] static method.
+    ///
+    /// [qt]: https://doc.qt.io/qt-5/qcoreapplication.html#applicationName-prop
+    pub fn set_application_name(application: QString) {
+        cpp!(unsafe [application as "QString"] {
+            QCoreApplication::setApplicationName(application);
+        });
+    }
+
+    /// Wrapper around [`QString applicationVersion()`][qt] static method.
+    ///
+    /// [qt]: https://doc.qt.io/qt-5/qcoreapplication.html#applicationVersion-prop
+    pub fn application_version() -> QString {
+        cpp!(unsafe [] -> QString as "QString" {
+            return QCoreApplication::applicationVersion();
+        })
+    }
+
+    /// Wrapper around [`void setApplicationVersion(const QString &version)`][qt] static method.
+    ///
+    /// [qt]: https://doc.qt.io/qt-5/qcoreapplication.html#applicationVersion-prop
+    pub fn set_application_version(version: QString) {
+        cpp!(unsafe [version as "QString"] {
+            QCoreApplication::setApplicationVersion(version);
+        });
+    }
+
+    /// Wrapper around [`QString organizationDomain()`][qt] static method.
+    ///
+    /// [qt]: https://doc.qt.io/qt-5/qcoreapplication.html#organizationDomain-prop
+    pub fn organization_domain() -> QString {
+        cpp!(unsafe [] -> QString as "QString" {
+            return QCoreApplication::organizationDomain();
+        })
+    }
+
+    /// Wrapper around [`void setOrganizationDomain(const QString &orgDomain)`][qt] static method.
+    ///
+    /// [qt]: https://doc.qt.io/qt-5/qcoreapplication.html#organizationDomain-prop
+    pub fn set_organization_domain(org_domain: QString) {
+        cpp!(unsafe [org_domain as "QString"] {
+            QCoreApplication::setOrganizationDomain(org_domain);
+        });
+    }
+
+    /// Wrapper around [`QString organizationName()`][qt] static method.
+    ///
+    /// [qt]: https://doc.qt.io/qt-5/qcoreapplication.html#organizationName-prop
+    pub fn organization_name() -> QString {
+        cpp!(unsafe [] -> QString as "QString" {
+            return QCoreApplication::organizationName();
+        })
+    }
+
+    /// Wrapper around [`void setOrganizationName(const QString &orgName)`][qt] static method.
+    ///
+    /// [qt]: https://doc.qt.io/qt-5/qcoreapplication.html#organizationName-prop
+    pub fn set_organization_name(org_name: QString) {
+        cpp!(unsafe [org_name as "QString"] {
+            QCoreApplication::setOrganizationName(org_name);
+        });
+    }
+
+    /// Wrapper around [`void QCoreApplication::quit()`][qt] static method.
+    ///
+    /// # Note
+    ///
+    /// Unlike the C library function of the same name, this function does
+    /// return to the caller — it is event processing that stops.
+    ///
+    /// [qt]: https://doc.qt.io/qt-5/qcoreapplication.html#quit
+    pub fn quit() {
+        cpp!(unsafe [] {
+            QCoreApplication::quit();
+        });
+    }
+}

--- a/qmetaobject/src/qtcore/mod.rs
+++ b/qmetaobject/src/qtcore/mod.rs
@@ -1,0 +1,21 @@
+/* Copyright (C) 2018 Olivier Goffart <ogoffart@woboq.com>
+   Copyright (C) 2021 ivan tkachenko a.k.a. ratijas <me@ratijas.tk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+//! Wrappers around QtCore module.
+
+pub mod core_application;

--- a/qmetaobject/tests/tests.rs
+++ b/qmetaobject/tests/tests.rs
@@ -979,3 +979,28 @@ fn test_qvariant_qimage_qpixmap() {
     img3.set_pixel_color(8, 8, QColor::from_name("black"));
     assert!(img2 != img3);
 }
+
+#[test]
+fn test_application_name() {
+    use qmetaobject::qtcore::core_application::*;
+
+    let app_name    = QString::from("qmetaobject-rs testing app");
+    let app_version = QString::from("0.1");
+    let org_domain  = QString::from("woboq.com");
+    let org_name    = QString::from("Woboq");
+
+    QCoreApplication::set_application_name(app_name.clone());
+    QCoreApplication::set_application_version(app_version.clone());
+    QCoreApplication::set_organization_domain(org_domain.clone());
+    QCoreApplication::set_organization_name(org_name.clone());
+
+    let app_name_    = QCoreApplication::application_name();
+    let app_version_ = QCoreApplication::application_version();
+    let org_domain_  = QCoreApplication::organization_domain();
+    let org_name_    = QCoreApplication::organization_name();
+
+    assert_eq!(app_name,    app_name_);
+    assert_eq!(app_version, app_version_);
+    assert_eq!(org_domain,  org_domain_);
+    assert_eq!(org_name,    org_name_);
+}


### PR DESCRIPTION
To be honest, I'm a bit concerned about the name of this new module, because core is also a part of rustc std.

---

Closes #113