### PR TITLE
Add QEnum to prelude and add example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,5 @@ members = [
     'examples/qmlextensionplugins',
     'examples/todos',
     'examples/webengine',
+    'examples/qenum',
 ]

--- a/examples/qenum/Cargo.toml
+++ b/examples/qenum/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "qenum"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+qmetaobject = { path = "../../qmetaobject" }
+cstr = "0.2"

--- a/examples/qenum/src/main.rs
+++ b/examples/qenum/src/main.rs
@@ -1,0 +1,32 @@
+
+use cstr::cstr;
+
+use qmetaobject::prelude::*;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, QEnum)]
+#[repr(u32)]
+enum Options {
+    Foo = 1,
+    Bar = 2,
+    Quaz = 3,
+}
+
+fn main() {
+    qml_register_enum::<Options>(cstr!("RustCode"), 1, 0, cstr!("Options"));
+    let mut engine = QmlEngine::new();
+    engine.load_data(r#"
+        import QtQuick 2.6
+        import QtQuick.Window 2.0
+        // Import our Rust classes
+        import RustCode 1.0
+
+        Window {
+            visible: true
+            Text {
+                anchors.centerIn: parent
+                text: `Hello! Bar is ${Options.Bar}, Foo is ${Options.Foo}.`
+            }
+        }
+    "#.into());
+    engine.exec();
+}

--- a/qmetaobject/src/lib.rs
+++ b/qmetaobject/src/lib.rs
@@ -216,9 +216,9 @@ pub mod webengine;
 pub mod prelude {
     pub use crate::{
         qml_register_type, qrc, qt_base_class, qt_method, qt_plugin, qt_property, qt_signal,
-        QAbstractListModel, QByteArray, QColor, QDate, QDateTime, QModelIndex, QObject, QObjectBox,
-        QPointer, QQmlExtensionPlugin, QQuickItem, QQuickView, QRectF, QString, QTime, QVariant,
-        QmlEngine,
+        qtdeclarative::qml_register_enum, QAbstractListModel, QByteArray, QColor, QDate, QDateTime,
+        QEnum, QModelIndex, QObject, QObjectBox, QPointer, QQmlExtensionPlugin, QQuickItem,
+        QQuickView, QRectF, QString, QTime, QVariant, QmlEngine,
     };
 }
 


### PR DESCRIPTION
I had a hard time figuring this out, but found this comment: https://github.com/woboq/qmetaobject-rs/issues/39#issuecomment-866254747

I think it's worthwhile to add an example that shows how to use it. 

The rationale behind adding qml_register_enum to the prelude is that these free functions are included early in the C++ headers and are expected to be "just there" pretty much always. Additionally, `qml_register_type` is in the prelude so I figured it makes sense to add `qml_register_enum` as well.
