### PR TITLE
Fix compilation with Qt 6.2 and MSVC

### DIFF
--- a/qmetaobject/build.rs
+++ b/qmetaobject/build.rs
@@ -36,6 +36,7 @@ fn main() {
     if qt_version >= Version::new(6, 0, 0) {
         config.flag_if_supported("-std=c++17");
         config.flag_if_supported("/std:c++17");
+        config.flag_if_supported("/Zc:__cplusplus");
     }
     config.include(&qt_include_path).build("src/lib.rs");
 

--- a/qttypes/build.rs
+++ b/qttypes/build.rs
@@ -148,6 +148,7 @@ fn main() {
     if qt_version >= Version::new(6, 0, 0) {
         config.flag_if_supported("-std=c++17");
         config.flag_if_supported("/std:c++17");
+        config.flag_if_supported("/Zc:__cplusplus");
     }
     config.include(&qt_include_path).build("src/lib.rs");
 

--- a/qttypes/src/lib.rs
+++ b/qttypes/src/lib.rs
@@ -83,6 +83,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //!         .include(format!("{}/QtCore", qt_include_path))
 //!         .flag_if_supported("-std=c++17")
 //!         .flag_if_supported("/std:c++17")
+//!         .flag_if_supported("/Zc:__cplusplus")
 //!         .build("src/main.rs");
 //! }
 //! ```


### PR DESCRIPTION
MSVC does not set the __cplusplus macro correctly by default. It is necessary to pass /Zc:__cplusplus,
which in turn Qt 6.2 requires now.

See also https://codereview.qt-project.org/c/qt/qtbase/+/334623