### PR TITLE
Add wrappers around `QJsonValue`, `QJsonArray` and `QJsonObject`

### DIFF
--- a/qmetaobject/src/qmetatype.rs
+++ b/qmetaobject/src/qmetatype.rs
@@ -488,6 +488,9 @@ impl QMetaType for QVariant {
     }
 }
 qdeclare_builtin_metatype! {QModelIndex => 42}
+qdeclare_builtin_metatype! {QJsonValue => 45}
+qdeclare_builtin_metatype! {QJsonObject => 46}
+qdeclare_builtin_metatype! {QJsonArray => 47}
 qdeclare_builtin_metatype! {QPixmap => if cfg!(qt_6_0) { 0x1001 } else { 65 }}
 qdeclare_builtin_metatype! {QColor => if cfg!(qt_6_0) { 0x1003 } else { 67 }}
 qdeclare_builtin_metatype! {QImage => if cfg!(qt_6_0) { 0x1006 } else { 70 }}

--- a/qttypes/src/lib.rs
+++ b/qttypes/src/lib.rs
@@ -1852,7 +1852,7 @@ cpp_class!(
 impl From<HashMap<String, String>> for QJsonObject {
     fn from(v: HashMap<String, String>) -> QJsonObject {
         let keys: Vec<QString> = v.keys().cloned().map(QString::from).collect();
-        let values: Vec<QString> = v.into_values().map(QString::from).collect();
+        let values: Vec<QString> = v.values().cloned().map(QString::from).collect();
         let keys_ptr = keys.as_ptr();
         let values_ptr = values.as_ptr();
         let len = keys.len();
@@ -1868,7 +1868,7 @@ impl From<HashMap<String, String>> for QJsonObject {
 impl From<HashMap<String, QJsonValue>> for QJsonObject {
     fn from(v: HashMap<String, QJsonValue>) -> QJsonObject {
         let keys: Vec<QString> = v.keys().cloned().map(QString::from).collect();
-        let values: Vec<QJsonValue> = v.into_values().collect();
+        let values: Vec<QJsonValue> = v.values().cloned().collect();
         let keys_ptr = keys.as_ptr();
         let values_ptr = values.as_ptr();
         let len = keys.len();


### PR DESCRIPTION
This PR adds basic wrappers around `QJsonValue`, `QJsonArray` and `QJsonObject` and registers the types in QMetaObject, allowing them to be used in `qt_method!`, `qt_property!` and `qt_signal!` macros