### PR TITLE
Added Methods to QStringList.

### DIFF
--- a/qttypes/src/lib.rs
+++ b/qttypes/src/lib.rs
@@ -1661,7 +1661,7 @@ impl QStringList {
         });
     }
 
-    pub fn append(&mut self, value: QString) {
+    pub fn push(&mut self, value: QString) {
         cpp!(unsafe [self as "QStringList*", value as "QString"] {
            self->append(value);
         });
@@ -1673,7 +1673,7 @@ impl QStringList {
         });
     }
 
-    pub fn remove_at(&mut self, index: usize) {
+    pub fn remove(&mut self, index: usize) {
         cpp!(unsafe [self as "QStringList*", index as "size_t"] {
             self->removeAt(index);
         })

--- a/qttypes/src/lib.rs
+++ b/qttypes/src/lib.rs
@@ -1706,6 +1706,25 @@ impl fmt::Debug for QStringList {
     }
 }
 
+#[test]
+fn test_qstringlist() {
+    let mut qstringlist = QStringList::new();
+    qstringlist.push("One".into());
+    qstringlist.push("Two".into());
+
+    assert_eq!(qstringlist.len(), 2);
+    assert_eq!(qstringlist[0], QString::from("One"));
+
+    qstringlist.remove(0);
+    assert_eq!(qstringlist[0], QString::from("Two"));
+
+    qstringlist.insert(0, "Three".into());
+    assert_eq!(qstringlist[0], QString::from("Three"));
+
+    qstringlist.clear();
+    assert_eq!(qstringlist.len(), 0);
+}
+
 cpp_class!(
     /// Wrapper around [`QJsonObject`][class] class.
     ///

--- a/qttypes/src/lib.rs
+++ b/qttypes/src/lib.rs
@@ -1649,10 +1649,41 @@ cpp_class!(
     pub unsafe struct QStringList as "QStringList"
 );
 impl QStringList {
+    pub fn new() -> QStringList {
+        cpp!(unsafe [] -> QStringList as "QStringList" {
+            return QStringList();
+        })
+    }
+
+    pub fn insert(&mut self, index: usize, value: QString) {
+        cpp!(unsafe [self as "QStringList*", index as "size_t", value as "QString"] {
+            self->insert(index, value);
+        });
+    }
+
+    pub fn append(&mut self, value: QString) {
+        cpp!(unsafe [self as "QStringList*", value as "QString"] {
+           self->append(value);
+        });
+    }
+
+    pub fn clear(&mut self) {
+        cpp!(unsafe [self as "QStringList*"] {
+            self->clear();
+        });
+    }
+
+    pub fn remove_at(&mut self, index: usize) {
+        cpp!(unsafe [self as "QStringList*", index as "size_t"] {
+            self->removeAt(index);
+        })
+    }
+
     pub fn len(&self) -> usize {
         cpp!(unsafe [self as "QStringList*"] -> usize as "size_t" { return self->size(); })
     }
 }
+
 impl Index<usize> for QStringList {
     type Output = QString;
 


### PR DESCRIPTION
Added methods for constructing QStringList from Rust Side.
Some methods in [ki18n-rs](https://github.com/Ayush1325/ki18n-rs) have QStringList as arguments and thus there need to be methods that allow the construction from Rust Side.