### PR TITLE
Add wrapper around qmlRegisterModule function

### DIFF
--- a/qmetaobject/src/lib.rs
+++ b/qmetaobject/src/lib.rs
@@ -216,6 +216,8 @@ pub mod webengine;
 pub mod prelude {
     #[cfg(qt_5_8)]
     pub use crate::qtdeclarative::qml_register_enum;
+    #[cfg(qt_5_9)]
+    pub use crate::qtdeclarative::qml_register_module;
     pub use crate::{
         qml_register_type, qrc, qt_base_class, qt_method, qt_plugin, qt_property, qt_signal,
         QAbstractListModel, QByteArray, QColor, QDate, QDateTime, QEnum, QModelIndex, QObject,

--- a/qmetaobject/src/qtdeclarative.rs
+++ b/qmetaobject/src/qtdeclarative.rs
@@ -502,6 +502,32 @@ pub fn qml_register_type<T: QObject + Default + Sized>(
     })
 }
 
+/// Wrapper around [`void qmlRegisterModule(const char *uri, int versionMajor, int versionMinor)`][qt] function.
+///
+/// [qt]: https://doc.qt.io/qt-5/qqmlengine.html#qmlRegisterModule
+#[cfg(qt_5_9)]
+pub fn qml_register_module(
+    uri: &CStr,
+    version_major: u32,
+    version_minor: u32,
+) {
+    let uri_ptr = uri.as_ptr();
+
+    cpp!(unsafe [
+        uri_ptr as "const char *",
+        version_major as "int",
+        version_minor as "int"
+    ] {
+    #if QT_VERSION >= QT_VERSION_CHECK(5,9,0)
+        qmlRegisterModule(
+            uri_ptr,
+            version_major,
+            version_minor
+        );
+    #endif
+    });
+}
+
 /// Alias for type of `QQmlPrivate::RegisterSingletonType::qobjectApi` callback
 /// and its C++ counterpart.
 type QmlRegisterSingletonTypeCallback =

--- a/qmetaobject/tests/tests.rs
+++ b/qmetaobject/tests/tests.rs
@@ -1066,5 +1066,4 @@ fn test_setting_context_object() {
     let res = _app.invoke_method("doTest".into(), &[]);
     let res: Option<i32> = QMetaType::from_qvariant(res);
     assert_eq!(res, Some(12));
-    assert_ne!(res, Some(10));
 }

--- a/qmetaobject/tests/tests.rs
+++ b/qmetaobject/tests/tests.rs
@@ -35,20 +35,20 @@ fn self_test() {
 
     let mut obj = Basic::default();
     obj.value = true;
-    assert!(do_test(obj, "Item { function doTest() { return _obj.value  } }"));
+    assert!(do_test(obj, "Item { function doTest() { return _obj.value;  } }"));
 
     let mut obj = Basic::default();
     obj.value = false;
-    assert!(!do_test(obj, "Item { function doTest() { return _obj.value  } }"));
+    assert!(!do_test(obj, "Item { function doTest() { return _obj.value;  } }"));
 }
 
 #[test]
 fn self_test_variant() {
     let obj = QVariant::from(true);
-    assert!(do_test_variant(obj, "Item { function doTest() { return _obj  } }"));
+    assert!(do_test_variant(obj, "Item { function doTest() { return _obj;  } }"));
 
     let obj = QVariant::from(false);
-    assert!(!do_test_variant(obj, "Item { function doTest() { return _obj  } }"));
+    assert!(!do_test_variant(obj, "Item { function doTest() { return _obj;  } }"));
 }
 
 #[derive(QObject, Default)]
@@ -91,24 +91,32 @@ fn property_read_write_notify() {
     let obj = MyObject::default();
     assert!(do_test(
         obj,
-        "Item {
-        property int yo: _obj.prop_x;
-        function doTest() {
-            _obj.prop_x = 123;
-            return yo === 123;
-        }}"
+        r"
+        Item {
+            property int yo: _obj.prop_x
+
+            function doTest() {
+                _obj.prop_x = 123;
+                return yo === 123;
+            }
+        }
+        "
     ));
 
     let obj = MyObject::default();
     assert!(do_test(
         obj,
-        "Item {
-        property string yo: _obj.prop_y + ' ' + _obj.prop_z;
-        function doTest() {
-            _obj.prop_y = 'hello';
-            _obj.prop_z = 'world';
-            return yo === 'hello world';
-        }}"
+        r"
+        Item {
+            property string yo: _obj.prop_y + ' ' + _obj.prop_z
+
+            function doTest() {
+                _obj.prop_y = 'hello';
+                _obj.prop_z = 'world';
+                return yo === 'hello world';
+            }
+        }
+        "
     ));
 }
 
@@ -117,10 +125,13 @@ fn call_method() {
     let obj = MyObject::default();
     assert!(do_test(
         obj,
-        "Item {
-        function doTest() {
-            return _obj.multiply_and_add1(45, 76) === 45*76+1;
-        }}"
+        r"
+        Item {
+            function doTest() {
+                return _obj.multiply_and_add1(45, 76) === 45 * 76 + 1;
+            }
+        }
+        "
     ));
 
     let obj = MyObject::default();
@@ -392,7 +403,7 @@ fn qpointer_properties() {
     );
     assert!(do_test(
         my_obj,
-        "
+        r"
         import SomeObjectLib 1.0
 
         Item {
@@ -425,7 +436,7 @@ fn qpointer_properties_incompatible() {
         CStr::from_bytes_with_nul(b"ObjectWithSome\0").unwrap(),
     );
     assert!(test_loading_logs(
-        "
+        r"
         import SomeObjectLib 1.0
 
         Item {
@@ -485,7 +496,7 @@ fn getter() {
     let my_obj = ObjectWithGetter::default();
     assert!(do_test(
         my_obj,
-        "
+        r"
         Item {
             function doTest() {
                 return _obj.prop_x === 85
@@ -524,7 +535,7 @@ fn setter() {
     let my_obj = ObjectWithGetter::default();
     assert!(do_test(
         my_obj,
-        "
+        r"
         Item {
             property var test: '' + _obj.prop_x + _obj.prop_y;
             function doTest() {
@@ -770,7 +781,7 @@ fn enum_properties() {
     let my_obj = MyObject::default();
     assert!(do_test(
         my_obj,
-        "
+        r"
         import MyEnumLib 1.0
 
         Item {
@@ -846,7 +857,7 @@ fn load_data_as() {
     obj.value = true;
     let error = do_test_error_with_url(
         obj,
-        "Item { function doTest() { return _intentional_error } }",
+        "Item { function doTest() { return _intentional_error; } }",
         "file:///path/file.ext",
     );
     assert!(error.contains("file:///path/file.ext"));
@@ -909,7 +920,7 @@ fn test_future() {
 #[test]
 fn create_component() {
     let _lock = lock_for_test();
-    let qml_text = "
+    let qml_text = r"
         import QtQuick 2.0
 
         Item {}
@@ -1032,7 +1043,15 @@ fn test_setting_context_object() {
         base: qt_base_class!(trait QObject),
         bvalue: qt_property!(i32),
     }
-    let qml_txt = "import QtQuick 2.0\nItem { function doTest() { return bvalue  } }";
+    let qml_txt = r"
+    import QtQuick 2.0
+
+    Item {
+        function doTest() {
+            return bvalue;
+        }
+    }
+    ";
 
     let _lock = lock_for_test();
     let mut _app = QmlEngine::new();

--- a/qmetaobject/tests/tests.rs
+++ b/qmetaobject/tests/tests.rs
@@ -200,6 +200,26 @@ fn register_type() {
     ));
 }
 
+#[test]
+#[cfg(qt_5_9)]
+fn register_module() {
+    qml_register_module(CStr::from_bytes_with_nul(b"TestEmptyModule\0").unwrap(), 1, 2);
+
+    let obj = MyObject::default(); // not used but needed for do_test
+    assert!(do_test(
+        obj,
+        r"
+        import TestEmptyModule 1.2 as TM
+
+        QtObject {
+            function doTest() {
+                return typeof TM === 'object';
+            }
+        }
+        "
+    ));
+}
+
 #[derive(Default, QObject)]
 struct RegisterSingletonInstanceObj {
     base: qt_base_class!(trait QObject),


### PR DESCRIPTION
This is a rarely used feature, but is still needed in some corner-cases.

Closes #219