### PR TITLE
feat(qmetaobject): add basic "is" wrappers for QJSValue

### DIFF
--- a/qmetaobject/src/qtdeclarative.rs
+++ b/qmetaobject/src/qtdeclarative.rs
@@ -927,6 +927,24 @@ cpp_class!(
 );
 
 impl QJSValue {
+    pub fn is_bool(&self) -> bool {
+        cpp!(unsafe [self as "const QJSValue *"] -> bool as "bool" {
+            return self->isBool();
+        })
+    }
+
+    pub fn is_number(&self) -> bool {
+        cpp!(unsafe [self as "const QJSValue *"] -> bool as "bool" {
+            return self->isNumber();
+        })
+    }
+
+    pub fn is_string(&self) -> bool {
+        cpp!(unsafe [self as "const QJSValue *"] -> bool as "bool" {
+            return self->isString();
+        })
+    }
+
     pub fn to_string(&self) -> QString {
         cpp!(unsafe [self as "const QJSValue *"] -> QString as "QString" {
             return self->toString();
@@ -1024,6 +1042,33 @@ mod qjsvalue_tests {
         assert_eq!(foo.to_number(), 45 as f64);
         assert_eq!(foo.to_string(), "45".into());
         assert_eq!(foo.to_variant().to_qbytearray(), "45".into());
+    }
+
+    #[test]
+    fn test_is_bool() {
+        let bool_value = QJSValue::from(true);
+        let num_value = QJSValue::from(42);
+
+        assert!(bool_value.is_bool());
+        assert!(!num_value.is_bool());
+    }
+
+    #[test]
+    fn test_is_number() {
+        let string_value = QJSValue::from(QString::from("Konqui"));
+        let num_value = QJSValue::from(42);
+
+        assert!(num_value.is_number());
+        assert!(!string_value.is_number());
+    }
+
+    #[test]
+    fn test_is_string() {
+        let string_value = QJSValue::from(QString::from("Konqui"));
+        let num_value = QJSValue::from(42);
+
+        assert!(string_value.is_string());
+        assert!(!num_value.is_string());
     }
 
     #[test]


### PR DESCRIPTION
I wasn't able to add wrapper for other types, since I couldn't construct values for unit-tests using From trait.

Ref #221 