### PR TITLE
Added QStandardPaths::StandardLocation enum.

### DIFF
--- a/qttypes/src/lib.rs
+++ b/qttypes/src/lib.rs
@@ -1222,6 +1222,34 @@ impl QPen {
     //    qreal	widthF() const
 }
 
+/// Bindings for [`QStandardPaths::StandardLocation`][enum] enum.
+///
+/// [enum]: https://doc.qt.io/qt-5/qstandardpaths.html#StandardLocation-enum
+#[repr(C)]
+#[derive(Clone, Copy, PartialEq, Debug)]
+#[allow(non_camel_case_types)]
+pub enum QStandardPathLocation {
+    DesktopLocation = 0,
+    DocumentsLocation = 1,
+    FontsLocation = 2,
+    ApplicationsLocation = 3,
+    MusicLocation = 4,
+    MoviesLocation = 5,
+    PicturesLocation = 6,
+    TempLocation = 7,
+    HomeLocation = 8,
+    AppLocalDataLocation = 9,
+    CacheLocation = 10,
+    GenericDataLocation = 11,
+    RuntimeLocation = 12,
+    ConfigLocation = 13,
+    DownloadLocation = 14,
+    GenericCacheLocation = 15,
+    GenericConfigLocation = 16,
+    AppDataLocation = 17,
+    AppConfigLocation = 18,
+}
+
 /// Bindings for [`Qt::BrushStyle`][enum] enum.
 ///
 /// [enum]: https://doc.qt.io/qt-5/qt.html#BrushStyle-enum


### PR DESCRIPTION
The documentation about this enum can be found [here](https://doc.qt.io/qt-5/qstandardpaths.html#StandardLocation-enum). I need this enum for [konfig](https://invent.kde.org/oreki/kconfig-rs). 
I also have a few questions about how to define this enum:
1. Naming: What is the naming convention for enums in qmetaobject. `QStandardPathsStandardLocation` seems too long which was followed for `QColorSpec` and a few other enums.
2. Multiple fields with the same value: C++ allows multiple enum fields to have the same integer value which is not allowed in Rust. In this enum, `AppLocalDataLocation` has the same value as `DataLocation`. Currently, I have defined it using a const but not sure if that is the correct way to do this.