### PR TITLE
Replaced repr(u32) with repr(C) in Enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ impl Graph {
 Alternatively, we could add a proper method wrapper, and call it without `unsafe`:
 
 ```rust
-#[repr(u32)]
+#[repr(C)]
 enum QQuickItemFlag {
     ItemClipsChildrenToShape = 0x01,
     ItemAcceptsInputMethod = 0x02,

--- a/examples/graph/src/main.rs
+++ b/examples/graph/src/main.rs
@@ -57,7 +57,7 @@ struct Graph {
 ///
 /// [enum]: https://doc.qt.io/qt-5/qquickitem.html#Flag-enum
 #[allow(unused)]
-#[repr(u32)]
+#[repr(C)]
 enum QQuickItemFlag {
     ItemClipsChildrenToShape = 0x01,
     ItemAcceptsInputMethod = 0x02,

--- a/examples/qenum/src/main.rs
+++ b/examples/qenum/src/main.rs
@@ -3,7 +3,7 @@ use cstr::cstr;
 use qmetaobject::prelude::*;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, QEnum)]
-#[repr(u32)]
+#[repr(C)]
 enum Options {
     Foo = 1,
     Bar = 2,

--- a/qmetaobject/src/qtdeclarative.rs
+++ b/qmetaobject/src/qtdeclarative.rs
@@ -299,7 +299,7 @@ impl Default for QQuickView {
 }
 
 /// See QQmlComponent::CompilationMode
-#[repr(u32)]
+#[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CompilationMode {
     PreferSynchronous,
@@ -307,7 +307,7 @@ pub enum CompilationMode {
 }
 
 /// See QQmlComponent::Status
-#[repr(u32)]
+#[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ComponentStatus {
     Null,
@@ -506,11 +506,7 @@ pub fn qml_register_type<T: QObject + Default + Sized>(
 ///
 /// [qt]: https://doc.qt.io/qt-5/qqmlengine.html#qmlRegisterModule
 #[cfg(qt_5_9)]
-pub fn qml_register_module(
-    uri: &CStr,
-    version_major: u32,
-    version_minor: u32,
-) {
+pub fn qml_register_module(uri: &CStr, version_major: u32, version_minor: u32) {
     let uri_ptr = uri.as_ptr();
 
     cpp!(unsafe [
@@ -889,7 +885,7 @@ impl<'a> dyn QQuickItem + 'a {
 /// Only a specific subset of [`QEvent::Type`][qt] enum.
 ///
 /// [qt]: https://doc.qt.io/qt-5/qevent.html#Type-enum
-#[repr(u32)]
+#[repr(C)]
 #[non_exhaustive]
 pub enum QMouseEventType {
     MouseButtonPress = 2,

--- a/qmetaobject_impl/src/qobject_impl.rs
+++ b/qmetaobject_impl/src/qobject_impl.rs
@@ -1153,7 +1153,8 @@ fn is_valid_repr_attribute(attribute: &syn::Attribute) -> bool {
             if list.path.is_ident("repr") && list.nested.len() == 1 {
                 match &list.nested[0] {
                     syn::NestedMeta::Meta(syn::Meta::Path(word)) => {
-                        const ACCEPTABLE_TYPES: &[&str] = &["u8", "u16", "u32", "i8", "i16", "i32"];
+                        const ACCEPTABLE_TYPES: &[&str] =
+                            &["u8", "u16", "u32", "i8", "i16", "i32", "C"];
                         ACCEPTABLE_TYPES.iter().any(|w| word.is_ident(w))
                     }
                     _ => false,
@@ -1178,7 +1179,7 @@ pub fn generate_enum(input: TokenStream, qt_version: QtVersion) -> TokenStream {
     if !is_repr_explicit {
         panic!(
             "#[derive(QEnum)] only support enum with explicit #[repr(*)], \
-                possible integer type are u8, u16, u32, i8, i16, i32."
+                possible types are u8, u16, u32, i8, i16, i32, C"
         )
     }
 

--- a/qmetaobject_impl/src/qobject_impl.rs
+++ b/qmetaobject_impl/src/qobject_impl.rs
@@ -1153,9 +1153,9 @@ fn is_valid_repr_attribute(attribute: &syn::Attribute) -> bool {
             if list.path.is_ident("repr") && list.nested.len() == 1 {
                 match &list.nested[0] {
                     syn::NestedMeta::Meta(syn::Meta::Path(word)) => {
-                        const ACCEPTABLE_TYPES: &[&str] =
+                        const ACCEPTABLE_REPRESENTATIONS: &[&str] =
                             &["u8", "u16", "u32", "i8", "i16", "i32", "C"];
-                        ACCEPTABLE_TYPES.iter().any(|w| word.is_ident(w))
+                        ACCEPTABLE_REPRESENTATIONS.iter().any(|w| word.is_ident(w))
                     }
                     _ => false,
                 }
@@ -1179,7 +1179,7 @@ pub fn generate_enum(input: TokenStream, qt_version: QtVersion) -> TokenStream {
     if !is_repr_explicit {
         panic!(
             "#[derive(QEnum)] only support enum with explicit #[repr(*)], \
-                possible types are u8, u16, u32, i8, i16, i32, C"
+                possible representations are u8, u16, u32, i8, i16, i32, C"
         )
     }
 

--- a/qttypes/src/gui/qcolor.rs
+++ b/qttypes/src/gui/qcolor.rs
@@ -68,7 +68,7 @@ impl Into<u64> for QRgba64 {
 /// Bindings for [`QColor::NameFormat`][class] enum class.
 ///
 /// [class]: https://doc.qt.io/qt-5/qcolor.html#NameFormat-enum
-#[repr(u32)]
+#[repr(C)]
 #[derive(Clone, Copy, PartialEq, Debug)]
 #[allow(non_camel_case_types)]
 pub enum QColorNameFormat {
@@ -81,7 +81,7 @@ pub enum QColorNameFormat {
 /// Bindings for [`QColor::Spec`][class] enum class.
 ///
 /// [class]: https://doc.qt.io/qt-5/qcolor.html#Spec-enum
-#[repr(u32)]
+#[repr(C)]
 #[derive(Clone, Copy, PartialEq, Debug)]
 #[allow(non_camel_case_types)]
 pub enum QColorSpec {

--- a/qttypes/src/lib.rs
+++ b/qttypes/src/lib.rs
@@ -1028,7 +1028,7 @@ pub struct QMargins {
 /// Bindings for [`QImage::Format`][class] enum class.
 ///
 /// [class]: https://doc.qt.io/qt-5/qimage.html#Format-enum
-#[repr(u32)]
+#[repr(C)]
 #[derive(Clone, Copy, PartialEq, Debug)]
 #[allow(non_camel_case_types)]
 pub enum ImageFormat {
@@ -1160,7 +1160,7 @@ impl From<QImage> for QPixmap {
 /// Bindings for [`Qt::PenStyle`][enum] enum.
 ///
 /// [enum]: https://doc.qt.io/qt-5/qt.html#PenStyle-enum
-#[repr(u32)]
+#[repr(C)]
 #[derive(Clone, Copy, PartialEq, Debug)]
 #[allow(non_camel_case_types)]
 pub enum PenStyle {
@@ -1253,7 +1253,7 @@ pub enum QStandardPathLocation {
 /// Bindings for [`Qt::BrushStyle`][enum] enum.
 ///
 /// [enum]: https://doc.qt.io/qt-5/qt.html#BrushStyle-enum
-#[repr(u32)]
+#[repr(C)]
 #[derive(Clone, Copy, PartialEq, Debug)]
 #[allow(non_camel_case_types)]
 pub enum BrushStyle {
@@ -1547,7 +1547,7 @@ impl QPainter {
 /// Bindings for [`QPainter::RenderHint`][enum] enum.
 ///
 /// [enum]: https://doc.qt.io/qt-5/qpainter.html#RenderHint-enum
-#[repr(u32)]
+#[repr(C)]
 #[derive(Clone, Copy, PartialEq, Debug)]
 #[allow(non_camel_case_types)]
 pub enum QPainterRenderHint {


### PR DESCRIPTION
This pull request is related to #228.
I have replaced all instances of `#[repr(u32)]` with `#[repr(C)]` for enums. 
I have also modified the derive macro of `QEnum` to allow `#[repr(C)]` and changed the examples accordingly.
