### PR TITLE
Implemented From for QStringList.

### DIFF
--- a/qttypes/Cargo.toml
+++ b/qttypes/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["api-bindings"]
 keywords = ["Qt", "QtCore", "QtGui"]
 repository = "https://github.com/woboq/qmetaobject-rs"
 links = "qt"
+rust-version = "1.56"
 
 [features]
 # When this feature is enabled (the default), the build script will panic with an error

--- a/qttypes/src/lib.rs
+++ b/qttypes/src/lib.rs
@@ -1760,6 +1760,20 @@ where
     }
 }
 
+impl<T> From<&[T]> for QStringList
+where
+    T: Clone,
+    QString: From<T>,
+{
+    fn from(s: &[T]) -> Self {
+        let mut list = QStringList::new();
+        for i in s {
+            list.push(QString::from(i.clone())); // i: &T in case of slice.
+        }
+        list
+    }
+}
+
 impl<T> From<QStringList> for Vec<T>
 where
     T: Clone,
@@ -1796,6 +1810,13 @@ fn test_qstringlist() {
     assert_eq!(qstringlist, QStringList::from(vec!["Three", "Two"]));
     assert_eq!(qstringlist, QStringList::from(vec!["Three".to_string(), "Two".to_string()]));
     assert_eq!(qstringlist, QStringList::from(vec![QString::from("Three"), QString::from("Two")]));
+
+    assert_eq!(qstringlist, QStringList::from(["Three", "Two"].as_slice()));
+    assert_eq!(qstringlist, QStringList::from(["Three".to_string(), "Two".to_string()].as_slice()));
+    assert_eq!(
+        qstringlist,
+        QStringList::from([QString::from("Three"), QString::from("Two")].as_slice())
+    );
 
     let temp: Vec<String> = qstringlist.clone().into();
     assert_eq!(temp, vec!["Three".to_string(), "Two".to_string()]);

--- a/qttypes/src/lib.rs
+++ b/qttypes/src/lib.rs
@@ -1811,12 +1811,12 @@ fn test_qstringlist() {
     assert_eq!(qstringlist, QStringList::from(vec!["Three".to_string(), "Two".to_string()]));
     assert_eq!(qstringlist, QStringList::from(vec![QString::from("Three"), QString::from("Two")]));
 
-    assert_eq!(qstringlist, QStringList::from(["Three", "Two"].as_slice()));
-    assert_eq!(qstringlist, QStringList::from(["Three".to_string(), "Two".to_string()].as_slice()));
-    assert_eq!(
-        qstringlist,
-        QStringList::from([QString::from("Three"), QString::from("Two")].as_slice())
-    );
+    let t = ["Three", "Two"];
+    assert_eq!(qstringlist, QStringList::from(t));
+    let t = ["Three".to_string(), "Two".to_string()];
+    assert_eq!(qstringlist, QStringList::from(t));
+    let t = [QString::from("Three"), QString::from("Two")];
+    assert_eq!(qstringlist, QStringList::from(t));
 
     let temp: Vec<String> = qstringlist.clone().into();
     assert_eq!(temp, vec!["Three".to_string(), "Two".to_string()]);

--- a/qttypes/src/lib.rs
+++ b/qttypes/src/lib.rs
@@ -1747,6 +1747,33 @@ where
     }
 }
 
+impl<T> From<Vec<T>> for QStringList
+where
+    QString: From<T>,
+{
+    fn from(s: Vec<T>) -> Self {
+        let mut list = QStringList::new();
+        for i in s {
+            list.push(QString::from(i));
+        }
+        list
+    }
+}
+
+impl<T> From<QStringList> for Vec<T>
+where
+    T: Clone,
+    QString: Into<T>,
+{
+    fn from(arr: QStringList) -> Self {
+        let mut v = Vec::with_capacity(arr.len());
+        for i in 0..arr.len() {
+            v.push(arr[i].clone().into());
+        }
+        v
+    }
+}
+
 #[test]
 fn test_qstringlist() {
     let mut qstringlist = QStringList::new();
@@ -1765,6 +1792,15 @@ fn test_qstringlist() {
     assert_eq!(qstringlist, QStringList::from(["Three", "Two"]));
     assert_eq!(qstringlist, QStringList::from(["Three".to_string(), "Two".to_string()]));
     assert_eq!(qstringlist, QStringList::from([QString::from("Three"), QString::from("Two")]));
+
+    assert_eq!(qstringlist, QStringList::from(vec!["Three", "Two"]));
+    assert_eq!(qstringlist, QStringList::from(vec!["Three".to_string(), "Two".to_string()]));
+    assert_eq!(qstringlist, QStringList::from(vec![QString::from("Three"), QString::from("Two")]));
+
+    let temp: Vec<String> = qstringlist.clone().into();
+    assert_eq!(temp, vec!["Three".to_string(), "Two".to_string()]);
+    let temp: Vec<QString> = qstringlist.clone().into();
+    assert_eq!(temp, vec![QString::from("Three"), QString::from("Two")]);
 
     qstringlist.clear();
     assert_eq!(qstringlist.len(), 0);

--- a/qttypes/src/lib.rs
+++ b/qttypes/src/lib.rs
@@ -1673,7 +1673,7 @@ cpp_class!(
     /// Wrapper around [`QStringList`][class] class.
     ///
     /// [class]: https://doc.qt.io/qt-5/qstringlist.html
-    #[derive(Default, Clone)]
+    #[derive(Default, Clone, PartialEq, Eq)]
     pub unsafe struct QStringList as "QStringList"
 );
 impl QStringList {
@@ -1734,6 +1734,19 @@ impl fmt::Debug for QStringList {
     }
 }
 
+impl<T, const N: usize> From<[T; N]> for QStringList
+where
+    QString: From<T>,
+{
+    fn from(s: [T; N]) -> Self {
+        let mut list = QStringList::new();
+        for i in s {
+            list.push(QString::from(i));
+        }
+        list
+    }
+}
+
 #[test]
 fn test_qstringlist() {
     let mut qstringlist = QStringList::new();
@@ -1748,6 +1761,10 @@ fn test_qstringlist() {
 
     qstringlist.insert(0, "Three".into());
     assert_eq!(qstringlist[0], QString::from("Three"));
+
+    assert_eq!(qstringlist, QStringList::from(["Three", "Two"]));
+    assert_eq!(qstringlist, QStringList::from(["Three".to_string(), "Two".to_string()]));
+    assert_eq!(qstringlist, QStringList::from([QString::from("Three"), QString::from("Two")]));
 
     qstringlist.clear();
     assert_eq!(qstringlist.len(), 0);


### PR DESCRIPTION
Can now do:
```rust
QStringList::from(["Three", "Two"]);
QStringList::from(["Three".to_string(), "Two".to_string()]);
QStringList::from([QString::from("Three"), QString::from("Two")]);
```