### PR TITLE
Added QVariantMap Type

### DIFF
--- a/qttypes/src/lib.rs
+++ b/qttypes/src/lib.rs
@@ -122,7 +122,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 use std::collections::HashMap;
 use std::convert::From;
-use std::fmt;
+use std::fmt::{self, Write};
 use std::iter::FromIterator;
 use std::ops::{Index, IndexMut};
 
@@ -557,6 +557,13 @@ impl QVariant {
 
     // FIXME: do more wrappers
 }
+
+impl fmt::Debug for QVariant {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.to_qbytearray().to_string().as_str())
+    }
+}
+
 impl From<QString> for QVariant {
     /// Wrapper around [`QVariant(const QString &)`][ctor] constructor.
     ///
@@ -881,6 +888,7 @@ cpp_class!(
     /// Wrapper around [`QVariantMap`][type] typedef.
     ///
     /// [type]: https://doc.qt.io/qt-5/qvariant.html#QVariantMap-typedef
+    #[derive(Default, PartialEq, Eq)]
     pub unsafe struct QVariantMap as "QVariantMap"
 );
 
@@ -970,6 +978,12 @@ impl IndexMut<QString> for QVariantMap {
                 return &(*self)[key];
             })
         }
+    }
+}
+
+impl fmt::Debug for QVariantMap {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_map().entries(self.into_iter()).finish()
     }
 }
 
@@ -1108,7 +1122,6 @@ mod qvariantmap_tests {
 
         for (k, v) in map.into_iter() {
             assert_eq!(hashmap[k.to_string().as_str()].to_string(), v.to_qbytearray().to_string());
-            // println!("Key: {}, Value: {}", k, v.to_qbytearray().to_string());
         }
     }
 }

--- a/qttypes/src/lib.rs
+++ b/qttypes/src/lib.rs
@@ -122,7 +122,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 use std::collections::HashMap;
 use std::convert::From;
-use std::fmt::{self, Write};
+use std::fmt;
 use std::hash::Hash;
 use std::iter::FromIterator;
 use std::ops::{Index, IndexMut};
@@ -185,8 +185,6 @@ cpp! {{
     #include <QtGui/QPainter>
     #include <QtGui/QPen>
     #include <QtGui/QBrush>
-
-    #include <tuple>
 }}
 
 cpp_class!(
@@ -1092,6 +1090,20 @@ where
     }
 }
 
+impl<K, V, const N: usize> From<[(K, V); N]> for QVariantMap
+where
+    K: Into<QString>,
+    V: Into<QVariant>,
+{
+    fn from(m: [(K, V); N]) -> Self {
+        let mut temp = QVariantMap::default();
+        for (key, val) in m {
+            temp.insert(key.into(), val.into());
+        }
+        temp
+    }
+}
+
 impl<K, V> From<QVariantMap> for HashMap<K, V>
 where
     K: Hash + Eq,
@@ -1154,9 +1166,15 @@ mod qvariantmap_tests {
             ("A".to_string(), QVariant::from(QString::from("abc"))),
             ("B".to_string(), QVariant::from(QString::from("def"))),
         ]);
-        let qvariantmap: QVariantMap = hashmap1.clone().into();
-        let hashmap2 = qvariantmap.into();
+        let qvariantmap1: QVariantMap = hashmap1.clone().into();
+        let hashmap2 = qvariantmap1.clone().into();
         assert_eq!(hashmap1, hashmap2);
+
+        let qvariantmap2 = QVariantMap::from([
+            ("A".to_string(), QVariant::from(QString::from("abc"))),
+            ("B".to_string(), QVariant::from(QString::from("def"))),
+        ]);
+        assert_eq!(qvariantmap1, qvariantmap2);
     }
 }
 

--- a/qttypes/src/lib.rs
+++ b/qttypes/src/lib.rs
@@ -876,6 +876,79 @@ mod tests {
 }
 
 cpp_class!(
+    /// Wrapper around [`QVariantMap`][type] typedef.
+    ///
+    /// [type]: https://doc.qt.io/qt-5/qvariant.html#QVariantMap-typedef
+    pub unsafe struct QVariantMap as "QVariantMap"
+);
+
+impl QVariantMap {
+    /// Wrapper around [`insert(int, const QString &, const QVariant &)`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qlist.html#insert
+    pub fn insert(&mut self, key: QString, element: QVariant) {
+        cpp!(unsafe [self as "QVariantMap*", key as "QString", element as "QVariant"] {
+            self->insert(key, std::move(element));
+        })
+    }
+
+    /// Wrapper around [`remove(const QString &)`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qmap.html#remove
+    pub fn remove(&mut self, key: QString) -> usize {
+        cpp!(unsafe [self as "QVariantMap*", key as "QString"] -> usize as "size_t" {
+            return self->remove(key);
+        })
+    }
+
+    /// Wrapper around [`take(const QString &)`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qmap.html#take
+    pub fn take(&mut self, key: QString) -> QVariant {
+        cpp!(unsafe [self as "QVariantMap*", key as "QString"] -> QVariant as "QVariant" {
+            return self->take(key);
+        })
+    }
+
+    /// Wrapper around [`size()`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qmap.html#size
+    pub fn len(&self) -> usize {
+        cpp!(unsafe [self as "QVariantMap*"] -> usize as "size_t" {
+            return self->size();
+        })
+    }
+
+    /// Wrapper around [`isEmpty()`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qmap.html#isEmpty
+    pub fn is_empty(&self) -> bool {
+        cpp!(unsafe [self as "QVariantMap*"] -> bool as "bool" {
+            return self->isEmpty();
+        })
+    }
+}
+
+#[cfg(test)]
+mod qvariantmap_tests {
+    use super::*;
+
+    #[test]
+    fn test_qvariantmap() {
+        let mut map = QVariantMap::default();
+
+        let key1 = QString::from("a");
+        let val1 = QString::from("abc");
+
+        assert!(map.is_empty());
+        map.insert(key1.clone(), val1.clone().into());
+        assert_eq!(map.len(), 1);
+        assert_eq!(map.take(key1.clone()).to_qbytearray().to_string(), val1.to_string());
+        assert!(map.is_empty());
+    }
+}
+
+cpp_class!(
     /// Wrapper around [`QModelIndex`][class] class.
     ///
     /// [class]: https://doc.qt.io/qt-5/qmodelindex.html

--- a/qttypes/src/lib.rs
+++ b/qttypes/src/lib.rs
@@ -945,6 +945,33 @@ impl QVariantMap {
             return self->contains(key);
         })
     }
+
+    /// Wrapper around [`clear()`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qmap.html#clear
+    pub fn clear(&mut self) {
+        cpp!(unsafe [self as "QVariantMap*"] {
+            self->clear();
+        })
+    }
+
+    /// Wrapper around [`value(const QString &, const QVariant &)`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qmap.html#value
+    pub fn value(&self, key: QString, default_value: QVariant) -> QVariant {
+        cpp!(unsafe [self as "QVariantMap*", key as "QString", default_value as "QVariant"] -> QVariant as "QVariant" {
+            return self->value(key, default_value);
+        })
+    }
+
+    /// Wrapper around [`key(const QVariant &, const QString &)`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qmap.html#key
+    pub fn key(&self, value: QVariant, default_key: QString) -> QString {
+        cpp!(unsafe [self as "QVariantMap*", default_key as "QString", value as "QVariant"] -> QString as "QString" {
+            return self->key(value, default_key);
+        })
+    }
 }
 
 impl Index<QString> for QVariantMap {
@@ -1136,7 +1163,15 @@ mod qvariantmap_tests {
         assert!(map.is_empty());
 
         map[key1.clone()] = val1.clone().into();
+
+        let default_value = QVariant::from(10);
+
         assert_eq!(map[key1.clone()].to_qbytearray().to_string(), val1.to_string());
+        assert_eq!(map.value(key1.clone(), default_value.clone()), val1.clone().into());
+        assert_eq!(map.value(val1.clone(), default_value.clone()), default_value.clone());
+
+        assert_eq!(map.key(val1.clone().into(), val1.clone()), key1.clone());
+        assert_eq!(map.key(key1.clone().into(), val1.clone()), val1.clone());
     }
 
     #[test]

--- a/qttypes/src/lib.rs
+++ b/qttypes/src/lib.rs
@@ -923,7 +923,7 @@ impl QVariantMap {
     ///
     /// [method]: https://doc.qt.io/qt-5/qmap.html#size
     pub fn len(&self) -> usize {
-        cpp!(unsafe [self as "QVariantMap*"] -> usize as "size_t" {
+        cpp!(unsafe [self as "const QVariantMap*"] -> usize as "size_t" {
             return self->size();
         })
     }
@@ -932,7 +932,7 @@ impl QVariantMap {
     ///
     /// [method]: https://doc.qt.io/qt-5/qmap.html#isEmpty
     pub fn is_empty(&self) -> bool {
-        cpp!(unsafe [self as "QVariantMap*"] -> bool as "bool" {
+        cpp!(unsafe [self as "const QVariantMap*"] -> bool as "bool" {
             return self->isEmpty();
         })
     }
@@ -941,7 +941,7 @@ impl QVariantMap {
     ///
     /// [method]: https://doc.qt.io/qt-5/qmap.html#contains
     pub fn contains(&self, key: QString) -> bool {
-        cpp!(unsafe [self as "QVariantMap*", key as "QString"] -> bool as "bool" {
+        cpp!(unsafe [self as "const QVariantMap*", key as "QString"] -> bool as "bool" {
             return self->contains(key);
         })
     }
@@ -959,7 +959,7 @@ impl QVariantMap {
     ///
     /// [method]: https://doc.qt.io/qt-5/qmap.html#value
     pub fn value(&self, key: QString, default_value: QVariant) -> QVariant {
-        cpp!(unsafe [self as "QVariantMap*", key as "QString", default_value as "QVariant"] -> QVariant as "QVariant" {
+        cpp!(unsafe [self as "const QVariantMap*", key as "QString", default_value as "QVariant"] -> QVariant as "QVariant" {
             return self->value(key, default_value);
         })
     }
@@ -968,7 +968,7 @@ impl QVariantMap {
     ///
     /// [method]: https://doc.qt.io/qt-5/qmap.html#key
     pub fn key(&self, value: QVariant, default_key: QString) -> QString {
-        cpp!(unsafe [self as "QVariantMap*", default_key as "QString", value as "QVariant"] -> QString as "QString" {
+        cpp!(unsafe [self as "const QVariantMap*", default_key as "QString", value as "QVariant"] -> QString as "QString" {
             return self->key(value, default_key);
         })
     }
@@ -981,24 +981,22 @@ impl Index<QString> for QVariantMap {
     ///
     /// [method]: https://doc.qt.io/qt-5/qlist.html#at
     #[track_caller]
-    fn index(&self, key: QString) -> &QVariant {
-        unsafe {
-            cpp!([self as "QVariantMap*", key as "QString"] -> *const QVariant as "const QVariant*" {
+    fn index(&self, key: QString) -> &Self::Output {
+        cpp!(unsafe [self as "const QVariantMap*", key as "QString"] -> Option<&QVariant> as "const QVariant*" {
                 auto x = self->constFind(key);
                 if (x == self->constEnd()) {
                     return NULL;
                 } else {
                     return &x.value();
                 }
-            }).as_ref()
-        }.expect("key not in the QVariant")
+            }).expect("key not in the QVariant")
     }
 }
 impl IndexMut<QString> for QVariantMap {
     /// Wrapper around [`operator[](int)`][method] operator method.
     ///
     /// [method]: https://doc.qt.io/qt-5/qlist.html#operator-5b-5d
-    fn index_mut(&mut self, key: QString) -> &mut QVariant {
+    fn index_mut(&mut self, key: QString) -> &mut Self::Output {
         unsafe {
             &mut *cpp!([self as "QVariantMap*", key as "QString"] -> *mut QVariant as "QVariant*" {
                 return &(*self)[key];
@@ -1015,9 +1013,7 @@ impl fmt::Debug for QVariantMap {
 
 cpp_class!(unsafe struct QVariantMapIteratorInternal as "QVariantMap::iterator");
 
-/// Internal class used to iterate over a [`QVariantMap`][]
-///
-/// [`QVariantMap`]: ./struct.QVariantMap.html
+/// Internal class used to iterate over a [`QVariantMap`]
 pub struct QVariantMapIterator<'a> {
     map: &'a QVariantMap,
     iterator: QVariantMapIteratorInternal,
@@ -1026,28 +1022,22 @@ pub struct QVariantMapIterator<'a> {
 impl<'a> QVariantMapIterator<'a> {
     fn key(&self) -> Option<&'a QString> {
         let iterator = &self.iterator;
-        unsafe {
-            cpp!([iterator as "QVariantMap::iterator*"] -> *mut QString as "const QString*" {
-                return &iterator->key();
-            })
-            .as_ref()
-        }
+        cpp!(unsafe [iterator as "const QVariantMap::iterator*"] -> Option<&QString> as "const QString*" {
+            return &iterator->key();
+        })
     }
 
     fn value(&self) -> Option<&'a QVariant> {
         let iterator = &self.iterator;
-        unsafe {
-            cpp!([iterator as "QVariantMap::iterator*"] -> *mut QVariant as "QVariant*" {
-                return &iterator->value();
-            })
-            .as_ref()
-        }
+        cpp!(unsafe [iterator as "const QVariantMap::iterator*"] -> Option<&QVariant> as "QVariant*" {
+            return &iterator->value();
+        })
     }
 
     fn check_end(&self) -> bool {
         let map = self.map;
         let iterator = &self.iterator;
-        cpp!(unsafe [iterator as "QVariantMap::iterator*", map as "QVariantMap*"] -> bool as "bool" {
+        cpp!(unsafe [iterator as "const QVariantMap::iterator*", map as "const QVariantMap*"] -> bool as "bool" {
             return (*iterator == map->end());
         })
     }


### PR DESCRIPTION
I'm not quite sure how to implement Iterator for QVariantMap. Any ideas?

Also, can someone check my implementation of `Index` trait. The `find()` method in QMap seems to return an iterator even though `insert()` replaces the old value if the key exists. So how can there be multiple values in the same key?

Finally, I'm not quite sure how to implement Iterator for QVariantMap.

Related to #232 