### PR TITLE
Add flag "/permissive-" for MSVC builds

### DIFF
--- a/qttypes/build.rs
+++ b/qttypes/build.rs
@@ -158,12 +158,16 @@ fn main() {
     let qt_version = qt_version.parse::<Version>().expect("Parsing Qt version failed");
 
     let mut config = cpp_build::Config::new();
-
+    
     if cargo_target_os == "macos" {
         config.flag("-F");
         config.flag(&qt_library_path);
     }
-
+    
+    if cargo_target_os == "windows" && cargo_target_env == "msvc" {
+        config.flag("/permissive-");
+    }
+    
     detect_qreal_size(&qt_include_path, &qt_library_path);
 
     if qt_version >= Version::new(6, 0, 0) {


### PR DESCRIPTION
Add flag "/permissive-" for MSVC builds for compatibility with Qt 6.3.0, solves issue #249 