### PR TITLE
Add methods for QStandardPathLocation.

### DIFF
--- a/qttypes/src/lib.rs
+++ b/qttypes/src/lib.rs
@@ -168,8 +168,8 @@ use internal_prelude::*;
 
 mod qtcore;
 pub use crate::qtcore::{
-    qreal, NormalizationForm, QByteArray, QListIterator, QString, QStringList, QUrl, QVariantList,
-    UnicodeVersion,
+    qreal, NormalizationForm, QByteArray, QListIterator, QStandardPathLocation, QString,
+    QStringList, QUrl, QVariantList, UnicodeVersion,
 };
 
 mod gui;
@@ -1380,34 +1380,6 @@ impl QPen {
     //    void	swap(QPen &other)
     //    int	width() const
     //    qreal	widthF() const
-}
-
-/// Bindings for [`QStandardPaths::StandardLocation`][enum] enum.
-///
-/// [enum]: https://doc.qt.io/qt-5/qstandardpaths.html#StandardLocation-enum
-#[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug)]
-#[allow(non_camel_case_types)]
-pub enum QStandardPathLocation {
-    DesktopLocation = 0,
-    DocumentsLocation = 1,
-    FontsLocation = 2,
-    ApplicationsLocation = 3,
-    MusicLocation = 4,
-    MoviesLocation = 5,
-    PicturesLocation = 6,
-    TempLocation = 7,
-    HomeLocation = 8,
-    AppLocalDataLocation = 9,
-    CacheLocation = 10,
-    GenericDataLocation = 11,
-    RuntimeLocation = 12,
-    ConfigLocation = 13,
-    DownloadLocation = 14,
-    GenericCacheLocation = 15,
-    GenericConfigLocation = 16,
-    AppDataLocation = 17,
-    AppConfigLocation = 18,
 }
 
 /// Bindings for [`Qt::BrushStyle`][enum] enum.

--- a/qttypes/src/qtcore/mod.rs
+++ b/qttypes/src/qtcore/mod.rs
@@ -2,6 +2,7 @@ mod primitives;
 mod qbytearray;
 mod qchar;
 mod qlist;
+mod qstandardpaths;
 mod qstring;
 mod qurl;
 
@@ -9,5 +10,6 @@ pub use self::primitives::qreal;
 pub use self::qbytearray::QByteArray;
 pub use self::qchar::UnicodeVersion;
 pub use self::qlist::{QListIterator, QStringList, QVariantList};
+pub use self::qstandardpaths::QStandardPathLocation;
 pub use self::qstring::{NormalizationForm, QString};
 pub use self::qurl::QUrl;

--- a/qttypes/src/qtcore/qstandardpaths.rs
+++ b/qttypes/src/qtcore/qstandardpaths.rs
@@ -1,0 +1,55 @@
+use crate::{cpp, QString, QStringList};
+
+cpp! {{
+    #include <QtCore/QStandardPaths>
+}}
+
+/// Bindings for [`QStandardPaths::StandardLocation`][enum] enum.
+///
+/// [enum]: https://doc.qt.io/qt-5/qstandardpaths.html#StandardLocation-enum
+#[repr(C)]
+#[derive(Clone, Copy, PartialEq, Debug)]
+#[allow(non_camel_case_types)]
+pub enum QStandardPathLocation {
+    DesktopLocation = 0,
+    DocumentsLocation = 1,
+    FontsLocation = 2,
+    ApplicationsLocation = 3,
+    MusicLocation = 4,
+    MoviesLocation = 5,
+    PicturesLocation = 6,
+    TempLocation = 7,
+    HomeLocation = 8,
+    AppLocalDataLocation = 9,
+    CacheLocation = 10,
+    GenericDataLocation = 11,
+    RuntimeLocation = 12,
+    ConfigLocation = 13,
+    DownloadLocation = 14,
+    GenericCacheLocation = 15,
+    GenericConfigLocation = 16,
+    AppDataLocation = 17,
+    AppConfigLocation = 18,
+}
+
+impl QStandardPathLocation {
+    pub fn display_name(t: Self) -> Option<QString> {
+        cpp!(unsafe [t as "QStandardPaths::StandardLocation"] -> QString as "QString" {
+            return QStandardPaths::displayName(t);
+        })
+        .to_option()
+    }
+
+    pub fn standard_locations(t: Self) -> QStringList {
+        cpp!(unsafe [t as "QStandardPaths::StandardLocation"] -> QStringList as "QStringList" {
+            return QStandardPaths::standardLocations(t);
+        })
+    }
+
+    pub fn writable_location(t: Self) -> Option<QString> {
+        cpp!(unsafe [t as "QStandardPaths::StandardLocation"] -> QString as "QString" {
+            return QStandardPaths::writableLocation(t);
+        })
+        .to_option()
+    }
+}

--- a/qttypes/src/qtcore/qstring.rs
+++ b/qttypes/src/qtcore/qstring.rs
@@ -184,6 +184,17 @@ impl QString {
             return self->normalized(mode, version);
         })
     }
+
+    /// A function that converts QString to Option<QString>.
+    /// Checks if the QString is null.
+    /// Note: null QString is differnt from empty QString.
+    pub fn to_option(self) -> Option<Self> {
+        if self.is_null() {
+            None
+        } else {
+            Some(self)
+        }
+    }
 }
 
 impl From<QUrl> for QString {


### PR DESCRIPTION
Also refactored QStandardPathLocation enum to separate module in qtcore (related to #235 ).

I have also added a `to_option()` method to `QString` (related to #253). Would like other people's input on this.