### PR TITLE
Fix call to `QMetaObject::invokeMethod` in Qt 6.5

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,6 +60,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
+        ver: [6.2.0, 6.5.0]
     env:
       QT_QPA_PLATFORM: offscreen
     runs-on: ${{ matrix.os }}
@@ -80,11 +81,11 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ../Qt
-        key: QtCache-${{ runner.os }}-6.2
+        key: QtCache-${{ runner.os }}-${{ matrix.ver }}
     - name: Install Qt
       uses: jurplel/install-qt-action@v2
       with:
-        version: 6.2.0
+        version: ${{ matrix.ver }}
         cached: ${{ steps.cache-qt6.outputs.cache-hit }}
     - name: Test
       run: |

--- a/qmetaobject/src/qtdeclarative.rs
+++ b/qmetaobject/src/qtdeclarative.rs
@@ -213,22 +213,18 @@ impl QmlEngine {
                 return {};
             }
             QVariant ret;
-            #if QT_VERSION >= QT_VERSION_CHECK(6,5,0)
-                #define INVOKE_METHOD(...) QMetaObject::invokeMethod(robjs.first(), name, qReturnArg(ret), __VA_ARGS__);
-            #else
-                #define INVOKE_METHOD(...) QMetaObject::invokeMethod(robjs.first(), name, Q_RETURN_ARG(QVariant, ret), __VA_ARGS__);
-            #endif
+            #define INVOKE_METHOD(...) QMetaObject::invokeMethod(robjs.first(), name, Q_RETURN_ARG(QVariant, ret) __VA_ARGS__);
             switch (args_size) {
-                case 0: INVOKE_METHOD() break;
-                case 1: INVOKE_METHOD(Q_ARG(QVariant, args_ptr[0])); break;
-                case 2: INVOKE_METHOD(Q_ARG(QVariant, args_ptr[0]), Q_ARG(QVariant, args_ptr[1])); break;
-                case 3: INVOKE_METHOD(Q_ARG(QVariant, args_ptr[0]), Q_ARG(QVariant, args_ptr[1]), Q_ARG(QVariant, args_ptr[2])); break;
-                case 4: INVOKE_METHOD(Q_ARG(QVariant, args_ptr[0]), Q_ARG(QVariant, args_ptr[1]), Q_ARG(QVariant, args_ptr[2]), Q_ARG(QVariant, args_ptr[3])); break;
-                case 5: INVOKE_METHOD(Q_ARG(QVariant, args_ptr[0]), Q_ARG(QVariant, args_ptr[1]), Q_ARG(QVariant, args_ptr[2]), Q_ARG(QVariant, args_ptr[3]), Q_ARG(QVariant, args_ptr[4])); break;
-                case 6: INVOKE_METHOD(Q_ARG(QVariant, args_ptr[0]), Q_ARG(QVariant, args_ptr[1]), Q_ARG(QVariant, args_ptr[2]), Q_ARG(QVariant, args_ptr[3]), Q_ARG(QVariant, args_ptr[4]), Q_ARG(QVariant, args_ptr[5])); break;
-                case 7: INVOKE_METHOD(Q_ARG(QVariant, args_ptr[0]), Q_ARG(QVariant, args_ptr[1]), Q_ARG(QVariant, args_ptr[2]), Q_ARG(QVariant, args_ptr[3]), Q_ARG(QVariant, args_ptr[4]), Q_ARG(QVariant, args_ptr[5]), Q_ARG(QVariant, args_ptr[6])); break;
-                case 8: INVOKE_METHOD(Q_ARG(QVariant, args_ptr[0]), Q_ARG(QVariant, args_ptr[1]), Q_ARG(QVariant, args_ptr[2]), Q_ARG(QVariant, args_ptr[3]), Q_ARG(QVariant, args_ptr[4]), Q_ARG(QVariant, args_ptr[5]), Q_ARG(QVariant, args_ptr[6]), Q_ARG(QVariant, args_ptr[7])); break;
-                case 9: INVOKE_METHOD(Q_ARG(QVariant, args_ptr[0]), Q_ARG(QVariant, args_ptr[1]), Q_ARG(QVariant, args_ptr[2]), Q_ARG(QVariant, args_ptr[3]), Q_ARG(QVariant, args_ptr[4]), Q_ARG(QVariant, args_ptr[5]), Q_ARG(QVariant, args_ptr[6]), Q_ARG(QVariant, args_ptr[7]), Q_ARG(QVariant, args_ptr[8])); break;
+                case 0: INVOKE_METHOD(); break;
+                case 1: INVOKE_METHOD(, Q_ARG(QVariant, args_ptr[0])); break;
+                case 2: INVOKE_METHOD(, Q_ARG(QVariant, args_ptr[0]), Q_ARG(QVariant, args_ptr[1])); break;
+                case 3: INVOKE_METHOD(, Q_ARG(QVariant, args_ptr[0]), Q_ARG(QVariant, args_ptr[1]), Q_ARG(QVariant, args_ptr[2])); break;
+                case 4: INVOKE_METHOD(, Q_ARG(QVariant, args_ptr[0]), Q_ARG(QVariant, args_ptr[1]), Q_ARG(QVariant, args_ptr[2]), Q_ARG(QVariant, args_ptr[3])); break;
+                case 5: INVOKE_METHOD(, Q_ARG(QVariant, args_ptr[0]), Q_ARG(QVariant, args_ptr[1]), Q_ARG(QVariant, args_ptr[2]), Q_ARG(QVariant, args_ptr[3]), Q_ARG(QVariant, args_ptr[4])); break;
+                case 6: INVOKE_METHOD(, Q_ARG(QVariant, args_ptr[0]), Q_ARG(QVariant, args_ptr[1]), Q_ARG(QVariant, args_ptr[2]), Q_ARG(QVariant, args_ptr[3]), Q_ARG(QVariant, args_ptr[4]), Q_ARG(QVariant, args_ptr[5])); break;
+                case 7: INVOKE_METHOD(, Q_ARG(QVariant, args_ptr[0]), Q_ARG(QVariant, args_ptr[1]), Q_ARG(QVariant, args_ptr[2]), Q_ARG(QVariant, args_ptr[3]), Q_ARG(QVariant, args_ptr[4]), Q_ARG(QVariant, args_ptr[5]), Q_ARG(QVariant, args_ptr[6])); break;
+                case 8: INVOKE_METHOD(, Q_ARG(QVariant, args_ptr[0]), Q_ARG(QVariant, args_ptr[1]), Q_ARG(QVariant, args_ptr[2]), Q_ARG(QVariant, args_ptr[3]), Q_ARG(QVariant, args_ptr[4]), Q_ARG(QVariant, args_ptr[5]), Q_ARG(QVariant, args_ptr[6]), Q_ARG(QVariant, args_ptr[7])); break;
+                case 9: INVOKE_METHOD(, Q_ARG(QVariant, args_ptr[0]), Q_ARG(QVariant, args_ptr[1]), Q_ARG(QVariant, args_ptr[2]), Q_ARG(QVariant, args_ptr[3]), Q_ARG(QVariant, args_ptr[4]), Q_ARG(QVariant, args_ptr[5]), Q_ARG(QVariant, args_ptr[6]), Q_ARG(QVariant, args_ptr[7]), Q_ARG(QVariant, args_ptr[8])); break;
             }
             #undef INVOKE_METHOD
             return ret;

--- a/qmetaobject/src/qtdeclarative.rs
+++ b/qmetaobject/src/qtdeclarative.rs
@@ -199,6 +199,8 @@ impl QmlEngine {
         let args_size = args.len();
         let args_ptr = args.as_ptr();
 
+        assert!(args_size <= 9);
+
         cpp!(unsafe [
             self as "QmlEngineHolder *",
             name as "QByteArray",
@@ -212,23 +214,23 @@ impl QmlEngine {
             }
             QVariant ret;
             #if QT_VERSION >= QT_VERSION_CHECK(6,5,0)
-                QMetaMethodArgument args[9] = {};
+                #define INVOKE_METHOD(...) QMetaObject::invokeMethod(robjs.first(), name, qReturnArg(ret), __VA_ARGS__);
             #else
-                QGenericArgument args[9] = {};
+                #define INVOKE_METHOD(...) QMetaObject::invokeMethod(robjs.first(), name, Q_RETURN_ARG(QVariant, ret), __VA_ARGS__);
             #endif
-            for (uint i = 0; i < args_size; ++i) {
-                args[i] = Q_ARG(QVariant, args_ptr[i]);
+            switch (args_size) {
+                case 0: INVOKE_METHOD() break;
+                case 1: INVOKE_METHOD(Q_ARG(QVariant, args_ptr[0])); break;
+                case 2: INVOKE_METHOD(Q_ARG(QVariant, args_ptr[0]), Q_ARG(QVariant, args_ptr[1])); break;
+                case 3: INVOKE_METHOD(Q_ARG(QVariant, args_ptr[0]), Q_ARG(QVariant, args_ptr[1]), Q_ARG(QVariant, args_ptr[2])); break;
+                case 4: INVOKE_METHOD(Q_ARG(QVariant, args_ptr[0]), Q_ARG(QVariant, args_ptr[1]), Q_ARG(QVariant, args_ptr[2]), Q_ARG(QVariant, args_ptr[3])); break;
+                case 5: INVOKE_METHOD(Q_ARG(QVariant, args_ptr[0]), Q_ARG(QVariant, args_ptr[1]), Q_ARG(QVariant, args_ptr[2]), Q_ARG(QVariant, args_ptr[3]), Q_ARG(QVariant, args_ptr[4])); break;
+                case 6: INVOKE_METHOD(Q_ARG(QVariant, args_ptr[0]), Q_ARG(QVariant, args_ptr[1]), Q_ARG(QVariant, args_ptr[2]), Q_ARG(QVariant, args_ptr[3]), Q_ARG(QVariant, args_ptr[4]), Q_ARG(QVariant, args_ptr[5])); break;
+                case 7: INVOKE_METHOD(Q_ARG(QVariant, args_ptr[0]), Q_ARG(QVariant, args_ptr[1]), Q_ARG(QVariant, args_ptr[2]), Q_ARG(QVariant, args_ptr[3]), Q_ARG(QVariant, args_ptr[4]), Q_ARG(QVariant, args_ptr[5]), Q_ARG(QVariant, args_ptr[6])); break;
+                case 8: INVOKE_METHOD(Q_ARG(QVariant, args_ptr[0]), Q_ARG(QVariant, args_ptr[1]), Q_ARG(QVariant, args_ptr[2]), Q_ARG(QVariant, args_ptr[3]), Q_ARG(QVariant, args_ptr[4]), Q_ARG(QVariant, args_ptr[5]), Q_ARG(QVariant, args_ptr[6]), Q_ARG(QVariant, args_ptr[7])); break;
+                case 9: INVOKE_METHOD(Q_ARG(QVariant, args_ptr[0]), Q_ARG(QVariant, args_ptr[1]), Q_ARG(QVariant, args_ptr[2]), Q_ARG(QVariant, args_ptr[3]), Q_ARG(QVariant, args_ptr[4]), Q_ARG(QVariant, args_ptr[5]), Q_ARG(QVariant, args_ptr[6]), Q_ARG(QVariant, args_ptr[7]), Q_ARG(QVariant, args_ptr[8])); break;
             }
-            QMetaObject::invokeMethod(
-                robjs.first(),
-                name,
-                #if QT_VERSION >= QT_VERSION_CHECK(6,5,0)
-                    qReturnArg(ret),
-                #else
-                    Q_RETURN_ARG(QVariant, ret),
-                #endif
-                args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8]
-            );
+            #undef INVOKE_METHOD
             return ret;
         })
     }


### PR DESCRIPTION
Invoking `QMetaObject::invokeMethod` with correct number of arguments didn't work correctly, because it checked the number of arguments with the signature of the function. Calling it explicitly with the right number of arguments fixes this issue.

Also added Qt 6.5 to the CI

Closes #286