### PR TITLE
Replaced QApplication from QtWidgets by QGuiApplication from QtGui

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,6 +60,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
+        ver: [6.2.0, 6.5.0]
     env:
       QT_QPA_PLATFORM: offscreen
     runs-on: ${{ matrix.os }}
@@ -80,11 +81,11 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ../Qt
-        key: QtCache-${{ runner.os }}-6.2
+        key: QtCache-${{ runner.os }}-${{ matrix.ver }}
     - name: Install Qt
       uses: jurplel/install-qt-action@v2
       with:
-        version: 6.2.0
+        version: ${{ matrix.ver }}
         cached: ${{ steps.cache-qt6.outputs.cache-hit }}
     - name: Test
       run: |

--- a/qmetaobject/src/qtdeclarative.rs
+++ b/qmetaobject/src/qtdeclarative.rs
@@ -28,7 +28,7 @@ cpp! {{
     #include <memory>
     #include <QtQuick/QtQuick>
     #include <QtCore/QDebug>
-    #include <QtWidgets/QApplication>
+    #include <QtGui/QGuiApplication>
     #include <QtQml/QQmlComponent>
 
     struct SingleApplicationGuard {
@@ -47,12 +47,12 @@ cpp! {{
     };
 
     struct QmlEngineHolder : SingleApplicationGuard {
-        std::unique_ptr<QApplication> app;
+        std::unique_ptr<QGuiApplication> app;
         std::unique_ptr<QQmlApplicationEngine> engine;
         std::unique_ptr<QQuickView> view;
 
         QmlEngineHolder(int &argc, char **argv)
-            : app(new QApplication(argc, argv))
+            : app(new QGuiApplication(argc, argv))
             , engine(new QQmlApplicationEngine())
         {}
     };

--- a/qttypes/build.rs
+++ b/qttypes/build.rs
@@ -228,7 +228,6 @@ fn main() {
     };
     link_lib("Core");
     link_lib("Gui");
-    link_lib("Widgets");
     #[cfg(feature = "qtquick")]
     link_lib("Quick");
     #[cfg(feature = "qtquick")]

--- a/qttypes/src/qtcore/qvariant.rs
+++ b/qttypes/src/qtcore/qvariant.rs
@@ -46,6 +46,15 @@ impl QVariant {
         })
     }
 
+    /// Wrapper around [`toList()`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qvariant.html#toList
+    pub fn to_list(&self) -> QVariantList {
+        cpp!(unsafe [self as "const QVariant*"] -> QVariantList as "QVariantList" {
+            return self->toList();
+        })
+    }
+
     /// Wrapper around [`toString()`][method] method.
     ///
     /// [method]: https://doc.qt.io/qt-5/qvariant.html#toString

--- a/qttypes/src/qtcore/qvariant.rs
+++ b/qttypes/src/qtcore/qvariant.rs
@@ -28,6 +28,15 @@ impl QVariant {
         })
     }
 
+    /// Wrapper around [`toMap()`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qvariant.html#toByteArray
+    pub fn to_map(&self) -> QVariantMap {
+        cpp!(unsafe [self as "const QVariant*"] -> QVariantMap as "QVariantMap" {
+            return self->toMap();
+        })
+    }
+
     /// Wrapper around [`userType()`][method] method.
     ///
     /// [method]: https://doc.qt.io/qt-5/qvariant.html#userType

--- a/qttypes/src/qtcore/qvariant.rs
+++ b/qttypes/src/qtcore/qvariant.rs
@@ -28,9 +28,18 @@ impl QVariant {
         })
     }
 
+    /// Wrapper around [`toDouble()`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qvariant.html#toDouble
+    pub fn to_double(&self) -> f64 {
+        cpp!(unsafe [self as "const QVariant*"] -> f64 as "double" {
+            return self->toDouble();
+        })
+    }
+
     /// Wrapper around [`toMap()`][method] method.
     ///
-    /// [method]: https://doc.qt.io/qt-5/qvariant.html#toByteArray
+    /// [method]: https://doc.qt.io/qt-5/qvariant.html#toMap
     pub fn to_map(&self) -> QVariantMap {
         cpp!(unsafe [self as "const QVariant*"] -> QVariantMap as "QVariantMap" {
             return self->toMap();

--- a/qttypes/src/qtcore/qvariant.rs
+++ b/qttypes/src/qtcore/qvariant.rs
@@ -46,6 +46,15 @@ impl QVariant {
         })
     }
 
+    /// Wrapper around [`toString()`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qvariant.html#toString
+    pub fn to_qstring(&self) -> QString {
+        cpp!(unsafe [self as "const QVariant*"] -> QString as "QString" {
+            return self->toString();
+        })
+    }
+
     /// Wrapper around [`userType()`][method] method.
     ///
     /// [method]: https://doc.qt.io/qt-5/qvariant.html#userType


### PR DESCRIPTION
When using QML the application class should be a QGuiApplication.
On targets without QtWidgets (my case on an aarch64 with a custom-build qt), the crate does not build. Replacing this class usage fixes it.
