### PR TITLE
Feature "qtwidgets" added.

### DIFF
--- a/qmetaobject/Cargo.toml
+++ b/qmetaobject/Cargo.toml
@@ -12,9 +12,10 @@ keywords = ["Qt", "QML", "QMetaObject",]
 repository = "https://github.com/woboq/qmetaobject-rs"
 
 [features]
-default = ["log"]
+default = ["log", "qtwidgets"]
 chrono_qdatetime = ["qttypes/chrono"]
 webengine = ["qttypes/qtwebengine"]
+qtwidgets = ["qttypes/qtwidgets"]
 
 [dependencies]
 qttypes = { path = "../qttypes", version = "0.2.0", features = ["qtquick"] }

--- a/qmetaobject/build.rs
+++ b/qmetaobject/build.rs
@@ -29,6 +29,10 @@ fn main() {
     for f in std::env::var("DEP_QT_COMPILE_FLAGS").unwrap().split_terminator(";") {
         config.flag(f);
     }
+
+    #[cfg(feature = "qtwidgets")]
+    config.define("USE_QTWIDGETS", None);
+
     config.include(&qt_include_path).build("src/lib.rs");
 
     for minor in 7..=15 {

--- a/qmetaobject/src/qtdeclarative.rs
+++ b/qmetaobject/src/qtdeclarative.rs
@@ -28,8 +28,15 @@ cpp! {{
     #include <memory>
     #include <QtQuick/QtQuick>
     #include <QtCore/QDebug>
-    #include <QtWidgets/QApplication>
     #include <QtQml/QQmlComponent>
+
+#if USE_QTWIDGETS
+    #include <QtWidgets/QApplication>
+    using QmlAppType = QApplication;
+#else
+    #include <QtGui/QGuiApplication>
+    using QmlAppType = QGuiApplication;
+#endif
 
     struct SingleApplicationGuard {
         SingleApplicationGuard() {
@@ -47,12 +54,13 @@ cpp! {{
     };
 
     struct QmlEngineHolder : SingleApplicationGuard {
-        std::unique_ptr<QApplication> app;
+        std::unique_ptr<QmlAppType> app;
+
         std::unique_ptr<QQmlApplicationEngine> engine;
         std::unique_ptr<QQuickView> view;
 
         QmlEngineHolder(int &argc, char **argv)
-            : app(new QApplication(argc, argv))
+            : app(new QmlAppType(argc, argv))
             , engine(new QQmlApplicationEngine())
         {}
     };

--- a/qttypes/Cargo.toml
+++ b/qttypes/Cargo.toml
@@ -20,6 +20,8 @@ required = []
 
 # Link against QtQuick
 qtquick = []
+# Link against QtWidgets
+qtwidgets = []
 # Link against QtWebEngine
 qtwebengine = []
 # Link against QtQuickControls2

--- a/qttypes/build.rs
+++ b/qttypes/build.rs
@@ -228,6 +228,7 @@ fn main() {
     };
     link_lib("Core");
     link_lib("Gui");
+    #[cfg(feature = "qtwidgets")]
     link_lib("Widgets");
     #[cfg(feature = "qtquick")]
     link_lib("Quick");

--- a/qttypes/src/lib.rs
+++ b/qttypes/src/lib.rs
@@ -112,6 +112,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //! | **`qtmultimedia`**        | Qt Multimedia         |
 //! | **`qtmultimediawidgets`** | Qt Multimedia Widgets |
 //! | **`qtquick`**             | Qt Quick              |
+//! | **`qtwidgets`**           | Qt Widgets            |
 //! | **`qtquickcontrols2`**    | Qt Quick Controls     |
 //! | **`qtsql`**               | Qt SQL                |
 //! | **`qttest`**              | Qt Test               |


### PR DESCRIPTION
Link with QtWidgets and use QApplication when activated (default) Use QGuiApplication when not.

Replaces #288 

I rewrote the patch in a new clean branch, keeping the master for my own projects dependency.

As #[cfg] and cpp! does not work well (if not at all together), I used a C++ predefined symbol to configure the used class.
Not as clean as I would like but I lost too much time already to figure out somthing that works.
Tell me if you have a better solution.