### PR TITLE
Error out when we detect incompatibilities between mingw and msvc

### DIFF
--- a/qttypes/build.rs
+++ b/qttypes/build.rs
@@ -211,6 +211,15 @@ fn main() {
             ""
         };
 
+    // MinGW and MSVC are not compatible
+    if cargo_target_os == "windows" {
+        let spec = qmake_query("QMAKE_SPEC");
+        if (spec.contains("msvc") && cargo_target_env == "gnu")
+            || (spec.contains("g++") && cargo_target_env == "msvc")
+        {
+            report_error(&format!("Rust target '{}' is not compatible with Qt mkspec '{spec}'. Mixing MinGW and MSVC is not allowed.", std::env::var_os("TARGET").unwrap_or_default().to_string_lossy()));
+        }
+    }
     /* https://github.com/rust-lang/cargo/issues/9562
     if std::env::var("CARGO_CFG_TARGET_FAMILY").as_ref().map(|s| s.as_ref()) == Ok("unix") {
         println!("cargo:rustc-cdylib-link-arg=-Wl,-rpath,{}", &qt_library_path);


### PR DESCRIPTION
This has caused lots of frustrations: eg:
https://github.com/slint-ui/slint/issues/3802
https://github.com/slint-ui/slint/issues/3539
https://github.com/slint-ui/slint/issues/3739