### PR TITLE
Qvariant improvements

### DIFF
--- a/qttypes/src/qtcore/qlist/qvariantlist.rs
+++ b/qttypes/src/qtcore/qlist/qvariantlist.rs
@@ -91,6 +91,12 @@ impl IndexMut<usize> for QVariantList {
     }
 }
 
+impl std::fmt::Debug for QVariantList {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_map().entries(self.into_iter().enumerate()).finish()
+    }
+}
+
 impl<'a> IntoIterator for &'a QVariantList {
     type Item = &'a QVariant;
     type IntoIter = QListIterator<'a, QVariantList, QVariant>;
@@ -159,5 +165,17 @@ mod tests {
         assert_eq!(qs1.to_string(), "hello");
         assert_eq!(qs2.to_string(), "hello");
         assert_eq!(qba4.to_string(), "hello");
+    }
+
+    #[test]
+    fn qvariantlist_debug() {
+        let mut list = QVariantList::default();
+        list.push(42.into());
+        list.push(QString::from("String!").into());
+        list.push(QByteArray::from("Bytearray!").into());
+        assert_eq!(
+            format!("{:?}", list),
+            "{0: QVariant(int: \"42\"), 1: QVariant(QString: \"String!\"), 2: QVariant(QByteArray: \"Bytearray!\")}"
+        );
     }
 }

--- a/qttypes/src/qtcore/qvariant.rs
+++ b/qttypes/src/qtcore/qvariant.rs
@@ -75,6 +75,15 @@ impl QVariant {
         })
     }
 
+    /// Wrapper around [`toInt()`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qvariant.html#toInt
+    pub fn to_int(&self) -> u32 {
+        cpp!(unsafe [self as "const QVariant*"] -> u32 as "int" {
+            return self->toInt();
+        })
+    }
+
     /// Wrapper around ['typeName()`][method] method.
     ///
     /// [method]: https://doc.qt.io/qt-5/qvariant.html#typeName
@@ -276,5 +285,12 @@ mod tests {
         let qv = QVariant::from(false);
         assert_eq!(qv.to_qstring().to_string(), String::from("false"));
         assert_eq!(format!("{:?}", qv), "QVariant(bool: \"false\")");
+    }
+
+    #[test]
+    fn qvariant_debug_int() {
+        let qv = QVariant::from(313);
+        assert_eq!(qv.to_int(), 313);
+        assert_eq!(format!("{:?}", qv), "QVariant(int: \"313\")");
     }
 }

--- a/qttypes/src/qtcore/qvariant.rs
+++ b/qttypes/src/qtcore/qvariant.rs
@@ -89,7 +89,13 @@ impl QVariant {
 
 impl fmt::Debug for QVariant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.to_qbytearray().to_string().as_str())
+        let data = self.to_qstring().to_string();
+        let qtype = self.type_name().to_string();
+        if data.len() == 0 {
+            f.write_fmt(format_args!("QVariant({})", qtype.as_str()))
+        } else {
+            f.write_fmt(format_args!("QVariant({}: \"{}\")", qtype.as_str(), data.as_str()))
+        }
     }
 }
 
@@ -252,4 +258,19 @@ where
     fn from(a: &'a T) -> QVariant {
         (*a).clone().into()
     }
+}
+
+
+#[test]
+fn qvariant_debug_qstring() {
+    let qv: QVariant = QString::from("Hello, QVariant!").into();
+    assert_eq!(qv.to_qstring().to_string(), "Hello, QVariant!");
+    assert_eq!(format!("{:?}", qv), "QVariant(QString: \"Hello, QVariant!\")");
+}
+
+#[test]
+fn qvariant_debug_bool() {
+    let qv = QVariant::from(false);
+    assert_eq!(qv.to_qstring().to_string(), String::from("false"));
+    assert_eq!(format!("{:?}", qv), "QVariant(bool: \"false\")");
 }

--- a/qttypes/src/qtcore/qvariant.rs
+++ b/qttypes/src/qtcore/qvariant.rs
@@ -66,6 +66,15 @@ impl QVariant {
         })
     }
 
+    /// Wrapper around [`toString()`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qvariant.html#toString
+    pub fn to_qstring(&self) -> QString {
+        cpp!(unsafe [self as "const QVariant*"] -> QString as "QString" {
+            return self->toString();
+        })
+    }
+
     // FIXME: do more wrappers
 }
 

--- a/qttypes/src/qtcore/qvariant.rs
+++ b/qttypes/src/qtcore/qvariant.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use crate::{
-    cpp, cpp_class, QByteArray, QDate, QDateTime, QString, QStringList, QTime, QUrl, QVariantList,
+    cpp, cpp_class, QByteArray, QDate, QDateTime, QString, QStringList, QTime, QUrl, QVariantList, QVariantMap
 };
 
 cpp_class!(
@@ -54,6 +54,15 @@ impl QVariant {
     pub fn is_null(&self) -> bool {
         cpp!(unsafe [self as "const QVariant*"] -> bool as "bool" {
             return self->isNull();
+        })
+    }
+
+    /// Wrapper around [`toMap()`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qvariant.html#toMap
+    pub fn to_qvariantmap(&self) -> QVariantMap {
+        cpp!(unsafe [self as "const QVariant*"] -> QVariantMap as "QVariantMap" {
+            return self->toMap();
         })
     }
 

--- a/qttypes/src/qtcore/qvariant.rs
+++ b/qttypes/src/qtcore/qvariant.rs
@@ -260,17 +260,21 @@ where
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-#[test]
-fn qvariant_debug_qstring() {
-    let qv: QVariant = QString::from("Hello, QVariant!").into();
-    assert_eq!(qv.to_qstring().to_string(), "Hello, QVariant!");
-    assert_eq!(format!("{:?}", qv), "QVariant(QString: \"Hello, QVariant!\")");
-}
+    #[test]
+    fn qvariant_debug_qstring() {
+        let qv: QVariant = QString::from("Hello, QVariant!").into();
+        assert_eq!(qv.to_qstring().to_string(), "Hello, QVariant!");
+        assert_eq!(format!("{:?}", qv), "QVariant(QString: \"Hello, QVariant!\")");
+    }
 
-#[test]
-fn qvariant_debug_bool() {
-    let qv = QVariant::from(false);
-    assert_eq!(qv.to_qstring().to_string(), String::from("false"));
-    assert_eq!(format!("{:?}", qv), "QVariant(bool: \"false\")");
+    #[test]
+    fn qvariant_debug_bool() {
+        let qv = QVariant::from(false);
+        assert_eq!(qv.to_qstring().to_string(), String::from("false"));
+        assert_eq!(format!("{:?}", qv), "QVariant(bool: \"false\")");
+    }
 }

--- a/qttypes/src/qtcore/qvariant.rs
+++ b/qttypes/src/qtcore/qvariant.rs
@@ -75,6 +75,15 @@ impl QVariant {
         })
     }
 
+    /// Wrapper around ['typeName()`][method] method.
+    ///
+    /// [method]: https://doc.qt.io/qt-5/qvariant.html#typeName
+    pub fn type_name(&self) -> QString {
+        cpp!(unsafe [self as "const QVariant*"] -> QString as "QString" {
+            return self->typeName();
+        })
+    }
+
     // FIXME: do more wrappers
 }
 

--- a/qttypes/src/qtcore/qvariant.rs
+++ b/qttypes/src/qtcore/qvariant.rs
@@ -92,9 +92,9 @@ impl fmt::Debug for QVariant {
         let data = self.to_qstring().to_string();
         let qtype = self.type_name().to_string();
         if data.len() == 0 {
-            f.write_fmt(format_args!("QVariant({})", qtype.as_str()))
+            write!(f, "QVariant({})", qtype.as_str())
         } else {
-            f.write_fmt(format_args!("QVariant({}: \"{}\")", qtype.as_str(), data.as_str()))
+            write!(f, "QVariant({}: \"{}\")", qtype.as_str(), data.as_str())
         }
     }
 }


### PR DESCRIPTION
- Add `to_qstring()` wrapper
  - More versatile and efficient than `.to_qbytearray().to_string()`
  - According to [documentation](https://doc.qt.io/archives/qt-5.6/qvariant.html#toString) e.g. `QVariant(QColor)` shouldn't be `toString()`able but it is
- Add `From<QVariantMap>` wrapper
  - Can save a move/clone on Rust side
- Improve debug print
  - Add `type_name` wrapper
  - Include the type QVariant contains with printable value, if any
  - Makes debugging QML<>Rust interactions easier

In Whisperfish for example debug prints like this are now possible:

```rust
tracing::debug!(tracing::debug!("Attachment: {:?}", attachment);
// Attachment: {data: QVariant(QString: "/home/defaultuser/Downloads/test.md"), type: QVariant(QString: "text/markdown")}
```

[Whisperfish!570](https://gitlab.com/whisperfish/whisperfish/-/merge_requests/570) currently depends on this (but it can (barely) do without)