### PR TITLE
Add QT bundled libraries behind features

### DIFF
--- a/qttypes/Cargo.toml
+++ b/qttypes/Cargo.toml
@@ -33,6 +33,13 @@ qtsql = []
 # Link against QtTest
 qttest = []
 
+qtbundledfreetype = []
+qtbundledharfbuzz = []
+qtbundledlibjpeg = []
+qtbundledlibpng = []
+qtbundledpcre2 = []
+qtbundledzlib = []
+
 default = ["required"]
 
 [dependencies]

--- a/qttypes/build.rs
+++ b/qttypes/build.rs
@@ -272,5 +272,19 @@ fn main() {
     link_lib("Sql");
     #[cfg(feature = "qttest")]
     link_lib("Test");
+
+    #[cfg(feature = "qtbundledfreetype")]
+    link_lib("BundledFreetype");
+    #[cfg(feature = "qtbundledharfbuzz")]
+    link_lib("BundledHarfbuzz");
+    #[cfg(feature = "qtbundledlibjpeg")]
+    link_lib("BundledLibjpeg");
+    #[cfg(feature = "qtbundledlibpng")]
+    link_lib("BundledLibpng");
+    #[cfg(feature = "qtbundledpcre2")]
+    link_lib("BundledPcre2");
+    #[cfg(feature = "qtbundledzlib")]
+    link_lib("BundledZLIB");
+
     println!("cargo:rerun-if-changed=src");
 }


### PR DESCRIPTION
This patch allows to link QT bundled libraries, behind feature flags. I use this to make fully static builds.