### PR TITLE
Add feature to link QWindowsIntegrationPlugin

### DIFF
--- a/qttypes/Cargo.toml
+++ b/qttypes/Cargo.toml
@@ -33,6 +33,8 @@ qtsql = []
 # Link against QtTest
 qttest = []
 
+staticruntime = []
+
 default = ["required"]
 
 [dependencies]

--- a/qttypes/build.rs
+++ b/qttypes/build.rs
@@ -272,5 +272,13 @@ fn main() {
     link_lib("Sql");
     #[cfg(feature = "qttest")]
     link_lib("Test");
+
+    #[cfg(feature = "staticruntime")]
+    if cargo_target_env == "msvc" {
+        let qt_plugins_path = qmake_query("QT_INSTALL_PLUGINS");
+        println!("cargo:rustc-link-search={}", &qt_plugins_path);
+        println!("cargo:rustc-link-lib=static=platforms/qwindows");
+    }
+
     println!("cargo:rerun-if-changed=src");
 }

--- a/qttypes/src/lib.rs
+++ b/qttypes/src/lib.rs
@@ -190,6 +190,13 @@ cpp! {{
     #include <QtGui/QBrush>
 }}
 
+#[cfg(feature = "staticruntime")]
+cpp! {{
+    #include <QtCore/QtPlugin>
+
+    Q_IMPORT_PLUGIN (QWindowsIntegrationPlugin)
+}}
+
 cpp_class!(
     /// Wrapper around [`QDate`][class] class.
     ///


### PR DESCRIPTION
To make fully static builds, linking the `qwindows` plugin seems to be required as well as importing `QWindowsIntegrationPlugin`.  I am not sure if this is the right way (or even the right place) to do this. 