### PR TITLE
Optionally link QtWidgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,16 @@ Enables `QtWebEngine` functionality. For more details see the [example](./exampl
 
 This feature is disabled by default.
 
+### `qtwidgets`
+
+Enables `QtWidgets` functionality and uses `QApplication` instead of `QGuiApplication`.
+This is useful for desktop applications that require widget styling and other widget-specific features.
+
+By default, the crate uses `QGuiApplication` which is sufficient for QtQuick-only applications.
+Enable this feature if your application needs `QApplication` or links against QtWidgets.
+
+This feature is disabled by default, and was introduced in qmetaobject 0.3.0.
+
 ## What if a wrapper for the Qt C++ API is missing?
 
 It is quite likely that you would like to call a particular Qt function which

--- a/qmetaobject/Cargo.toml
+++ b/qmetaobject/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qmetaobject"
-version = "0.2.10"
+version = "0.3.0"
 edition = "2018"
 authors = ["Olivier Goffart <olivier.goffart@slint.dev>"]
 build = "build.rs"
@@ -18,7 +18,7 @@ webengine = ["qttypes/qtwebengine"]
 qtwidgets = ["qttypes/qtwidgets"]
 
 [dependencies]
-qttypes = { path = "../qttypes", version = "0.2.0", features = ["qtquick"] }
+qttypes = { path = "../qttypes", version = "0.3.0", features = ["qtquick"] }
 qmetaobject_impl = { path = "../qmetaobject_impl", version = "=0.2.10"}
 lazy_static = "1.0"
 cpp = "0.5.6"

--- a/qmetaobject/Cargo.toml
+++ b/qmetaobject/Cargo.toml
@@ -15,6 +15,7 @@ repository = "https://github.com/woboq/qmetaobject-rs"
 default = ["log"]
 chrono_qdatetime = ["qttypes/chrono"]
 webengine = ["qttypes/qtwebengine"]
+qtwidgets = ["qttypes/qtwidgets"]
 
 [dependencies]
 qttypes = { path = "../qttypes", version = "0.2.0", features = ["qtquick"] }

--- a/qmetaobject/build.rs
+++ b/qmetaobject/build.rs
@@ -29,6 +29,10 @@ fn main() {
     for f in std::env::var("DEP_QT_COMPILE_FLAGS").unwrap().split_terminator(";") {
         config.flag(f);
     }
+
+    #[cfg(feature = "qtwidgets")]
+    config.define("QMETAOBJECT_HAS_QTWIDGETS", None);
+
     config.include(&qt_include_path).build("src/lib.rs");
 
     let versions = [

--- a/qmetaobject/src/qtdeclarative.rs
+++ b/qmetaobject/src/qtdeclarative.rs
@@ -28,7 +28,7 @@ cpp! {{
     #include <memory>
     #include <QtQuick/QtQuick>
     #include <QtCore/QDebug>
-    #include <QtWidgets/QApplication>
+    #include <QtGui/QGuiApplication>
     #include <QtQml/QQmlComponent>
 
     struct SingleApplicationGuard {
@@ -47,12 +47,12 @@ cpp! {{
     };
 
     struct QmlEngineHolder : SingleApplicationGuard {
-        std::unique_ptr<QApplication> app;
+        std::unique_ptr<QGuiApplication> app;
         std::unique_ptr<QQmlApplicationEngine> engine;
         std::unique_ptr<QQuickView> view;
 
         QmlEngineHolder(int &argc, char **argv)
-            : app(new QApplication(argc, argv))
+            : app(new QGuiApplication(argc, argv))
             , engine(new QQmlApplicationEngine())
         {}
     };
@@ -248,7 +248,7 @@ impl QmlEngine {
             if (robjs.isEmpty()) {
                 return;
             }
-            
+
             #define INVOKE_METHOD(...) QMetaObject::invokeMethod(robjs.first(), name __VA_ARGS__);
             switch (args_size) {
                 case 0: INVOKE_METHOD(); break;
@@ -277,7 +277,7 @@ impl QmlEngine {
             self->engine->clearComponentCache();
         })
     }
-    
+
     /// Give a QObject to the engine by wrapping it in a QJSValue
     ///
     /// This will create the C++ object.

--- a/qmetaobject/src/qtdeclarative.rs
+++ b/qmetaobject/src/qtdeclarative.rs
@@ -28,7 +28,13 @@ cpp! {{
     #include <memory>
     #include <QtQuick/QtQuick>
     #include <QtCore/QDebug>
-    #include <QtGui/QGuiApplication>
+    #if defined(QMETAOBJECT_HAS_QTWIDGETS)
+        #include <QtWidgets/QApplication>
+        using QmlAppType = QApplication;
+    #else
+        #include <QtGui/QGuiApplication>
+        using QmlAppType = QGuiApplication;
+    #endif
     #include <QtQml/QQmlComponent>
 
     struct SingleApplicationGuard {
@@ -47,12 +53,12 @@ cpp! {{
     };
 
     struct QmlEngineHolder : SingleApplicationGuard {
-        std::unique_ptr<QGuiApplication> app;
+        std::unique_ptr<QmlAppType> app;
         std::unique_ptr<QQmlApplicationEngine> engine;
         std::unique_ptr<QQuickView> view;
 
         QmlEngineHolder(int &argc, char **argv)
-            : app(new QGuiApplication(argc, argv))
+            : app(new QmlAppType(argc, argv))
             , engine(new QQmlApplicationEngine())
         {}
     };

--- a/qttypes/Cargo.toml
+++ b/qttypes/Cargo.toml
@@ -18,6 +18,8 @@ rust-version = "1.56"
 # if Qt is not found.
 required = []
 
+# Link against QtWidgets
+qtwidgets = []
 # Link against QtQuick
 qtquick = []
 # Link against QtWebEngine

--- a/qttypes/Cargo.toml
+++ b/qttypes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qttypes"
-version = "0.2.12"
+version = "0.3.0"
 edition = "2018"
 authors = ["Olivier Goffart <olivier.goffart@slint.dev>"]
 build = "build.rs"

--- a/qttypes/build.rs
+++ b/qttypes/build.rs
@@ -243,6 +243,7 @@ fn main() {
     };
     link_lib("Core");
     link_lib("Gui");
+    #[cfg(feature = "qtwidgets")]
     link_lib("Widgets");
     #[cfg(feature = "qtquick")]
     link_lib("Quick");

--- a/qttypes/src/lib.rs
+++ b/qttypes/src/lib.rs
@@ -116,6 +116,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //! | **`qtsql`**               | Qt SQL                |
 //! | **`qttest`**              | Qt Test               |
 //! | **`qtwebengine`**         | Qt WebEngine          |
+//! | **`qtwidgets`**           | Qt Widgets            |
 //!
 
 #![cfg_attr(no_qt, allow(unused))]


### PR DESCRIPTION
This makes qtwidgets a feature in qttypes, and makes qmetaobject-rs use `QGuiApplication` instead of `QApplication`. This means you don't have to link to QtWidgets when not necessary otherwise.