### PR TITLE
chore: bump syn to 2

### DIFF
--- a/qmetaobject_impl/Cargo.toml
+++ b/qmetaobject_impl/Cargo.toml
@@ -14,6 +14,6 @@ repository = "https://github.com/woboq/qmetaobject-rs"
 proc-macro = true
 
 [dependencies]
-syn = { version = "1", features = ["full"] }
+syn = { version = "2", features = ["full"] }
 quote = "1"
 proc-macro2 = "1"

--- a/qmetaobject_impl/src/lib.rs
+++ b/qmetaobject_impl/src/lib.rs
@@ -35,19 +35,22 @@ mod simplelistitem_impl;
 /// the QMetaObjectCrate is specified
 fn get_crate(input: &DeriveInput) -> impl ToTokens {
     for i in input.attrs.iter() {
-        if let Ok(x) = i.parse_meta() {
-            if x.path().is_ident("QMetaObjectCrate") {
-                if let syn::Meta::NameValue(mnv) = x {
-                    use syn::Lit::*;
-                    let lit: syn::Path = match mnv.lit {
-                        Str(s) => syn::parse_str(&s.value())
-                            .expect("Can't parse QMetaObjectCrate Attribute"),
-                        _ => panic!("Can't parse QMetaObjectCrate Attribute"),
-                    };
-                    return quote!( #lit );
-                }
-            }
+        let syn::Meta::NameValue(mnv) = &i.meta else {
+            continue;
+        };
+        if !mnv.path.is_ident("QMetaObjectCrate") {
+            continue;
         }
+
+        let syn::Expr::Lit(expr_lit) = &mnv.value else {
+            panic!("#[QMetaObjectCrate = \"path::to::crate\"] expects a string literal")
+        };
+        let syn::Lit::Str(s) = &expr_lit.lit else {
+            panic!("Can't parse QMetaObjectCrate Attribute")
+        };
+        let lit: syn::Path =
+            syn::parse_str(&s.value()).expect("Can't parse QMetaObjectCrate Attribute");
+        return quote!( #lit );
     }
 
     quote!(::qmetaobject)

--- a/qmetaobject_impl/src/qobject_impl.rs
+++ b/qmetaobject_impl/src/qobject_impl.rs
@@ -586,21 +586,23 @@ pub fn generate(input: TokenStream, is_qobject: bool, qt_version: QtVersion) -> 
                 }
             }
             for i in f.attrs.iter() {
-                if let Ok(x) = i.parse_meta() {
-                    if x.path().is_ident("qt_base_class") {
-                        if let syn::Meta::NameValue(mnv) = x {
-                            if let syn::Lit::Str(s) = mnv.lit {
-                                base = unwrap_parse_error!(syn::parse_str(&s.value()));
-                                base_prop = f.ident.clone().expect("base prop needs a name");
-                                has_base_property = true;
-                            } else {
-                                panic!("Can't parse qt_base_class");
-                            }
-                        } else {
-                            panic!("Can't parse qt_base_class");
-                        }
-                    }
+                let syn::Meta::NameValue(mnv) = &i.meta else {
+                    continue;
+                };
+                if !mnv.path.is_ident("qt_base_class") {
+                    continue;
                 }
+
+                let syn::Expr::Lit(expr_lit) = &mnv.value else {
+                    panic!("Can't parse qt_base_class");
+                };
+                let syn::Lit::Str(s) = &expr_lit.lit else {
+                    panic!("Can't parse qt_base_class");
+                };
+
+                base = unwrap_parse_error!(syn::parse_str(&s.value()));
+                base_prop = f.ident.clone().expect("base prop needs a name");
+                has_base_property = true;
             }
         }
     } else {
@@ -1143,23 +1145,30 @@ pub fn generate(input: TokenStream, is_qobject: bool, qt_version: QtVersion) -> 
 }
 
 fn is_valid_repr_attribute(attribute: &syn::Attribute) -> bool {
-    match attribute.parse_meta() {
-        Ok(syn::Meta::List(list)) => {
-            if list.path.is_ident("repr") && list.nested.len() == 1 {
-                match &list.nested[0] {
-                    syn::NestedMeta::Meta(syn::Meta::Path(word)) => {
-                        const ACCEPTABLE_REPRESENTATIONS: &[&str] =
-                            &["u8", "u16", "u32", "i8", "i16", "i32", "C"];
-                        ACCEPTABLE_REPRESENTATIONS.iter().any(|w| word.is_ident(w))
-                    }
-                    _ => false,
-                }
-            } else {
-                false
-            }
-        }
-        _ => false,
+    let syn::Meta::List(list) = &attribute.meta else {
+        return false;
+    };
+    if !list.path.is_ident("repr") {
+        return false;
     }
+
+    // Parse the tokens inside the list
+    let parser = syn::punctuated::Punctuated::<syn::Meta, Token![,]>::parse_terminated;
+    // parse2 keeps us in proc_macro2 TokenStream domain and preserves spans
+    let Ok(nested) = parser.parse2(list.tokens.clone()) else {
+        return false;
+    };
+
+    if nested.len() != 1 {
+        return false;
+    }
+
+    let syn::Meta::Path(word) = &nested.first().unwrap() else {
+        return false;
+    };
+
+    const ACCEPTABLE_REPRESENTATIONS: &[&str] = &["u8", "u16", "u32", "i8", "i16", "i32", "C"];
+    return ACCEPTABLE_REPRESENTATIONS.iter().any(|w| word.is_ident(w));
 }
 
 pub fn generate_enum(input: TokenStream, qt_version: QtVersion) -> TokenStream {

--- a/qmetaobject_impl/src/qrc_impl.rs
+++ b/qmetaobject_impl/src/qrc_impl.rs
@@ -90,7 +90,7 @@ impl Parse for Resource {
         let files = {
             let content;
             braced!(content in input);
-            content.parse_terminated::<File, Token![,]>(File::parse)?.into_iter().collect()
+            content.parse_terminated(File::parse, Token![,])?.into_iter().collect()
         };
         Ok(Resource { base_dir, prefix, files })
     }
@@ -135,8 +135,7 @@ impl Parse for QrcMacro {
         let func = input.parse()?;
         input.parse::<Option<Token![,]>>()?;
         // Rest of tokens are `Resource`s separated by comma
-        let data =
-            input.parse_terminated::<Resource, Token![,]>(Resource::parse)?.into_iter().collect();
+        let data = input.parse_terminated(Resource::parse, Token![,])?.into_iter().collect();
         Ok(QrcMacro { func, data })
     }
 }


### PR DESCRIPTION
The whole ecosystem seems to have moved on to syn 2, including cpp/cpp_build etc. These dependencies don't see that as a breaking change. AFAICT, neither should we, because all the parse trees stay internal.

I took the liberty of flattening the nesting of the parts this change touched.