### PR TITLE
feat: QQmlExtensionPlugin::initialize_engine

### DIFF
--- a/qmetaobject/src/qtdeclarative.rs
+++ b/qmetaobject/src/qtdeclarative.rs
@@ -1188,6 +1188,19 @@ pub trait QQmlExtensionPlugin: QObject {
 
     /// Refer to the Qt documentation of QQmlExtensionPlugin::registerTypes
     fn register_types(&mut self, uri: &CStr);
+
+    /// Refer to the Qt documentation of QQmlExtensionPlugin::initializeEngine
+    ///
+    /// This method is called after `register_types` and provides access to the
+    /// QQmlEngine instance. Use this method to install custom image providers,
+    /// set context properties, or perform other engine-wide initialization.
+    ///
+    /// # Arguments
+    /// * `engine` - A mutable reference to the QQmlEngine instance.
+    fn initialize_engine(&mut self, engine: &mut QQmlEngine, uri: &CStr) {
+        let _ = engine;
+        let _ = uri;
+    }
 }
 
 cpp! {{
@@ -1201,6 +1214,20 @@ cpp! {{
                 uri: *const c_char as "const char *"
             ] {
                 rust_object.borrow_mut().register_types(unsafe { CStr::from_ptr(uri) });
+            });
+        }
+
+        void initializeEngine(QQmlEngine *engine, const char *uri) override {
+            rust!(Rust_QQmlExtensionPlugin_initializeEngine[
+                rust_object: QObjectPinned<dyn QQmlExtensionPlugin> as "TraitObject",
+                engine: *mut QQmlEngine as "QQmlEngine *",
+                uri: *const c_char as "const char *"
+            ] {
+                let engine = unsafe {
+                    engine.as_mut().expect("non-null engine")
+                };
+                let uri = CStr::from_ptr(uri);
+                rust_object.borrow_mut().initialize_engine(engine, uri);
             });
         }
     };

--- a/qmetaobject/src/qtdeclarative.rs
+++ b/qmetaobject/src/qtdeclarative.rs
@@ -162,6 +162,16 @@ impl std::ops::Deref for QmlEngine {
     }
 }
 
+impl std::ops::DerefMut for QmlEngine {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        let ptr: *mut QQmlEngine = cpp!(unsafe [self as "QmlEngineHolder *"] -> *mut QQmlEngine as "QQmlEngine *" {
+            return self->engine.get();
+        });
+
+        unsafe { ptr.as_mut().expect("valid QQmlEngine") }
+    }
+}
+
 impl QmlEngine {
     /// Create a new QmlEngine
     pub fn new() -> QmlEngine {

--- a/qmetaobject/src/qtdeclarative.rs
+++ b/qmetaobject/src/qtdeclarative.rs
@@ -24,6 +24,70 @@ use crate::*;
 /// So this is a guard that will be used to panic if the engine is created twice
 static HAS_ENGINE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
+cpp_class!(
+    /// Wrapper around [`QQmlEngine`][class] class.
+    ///
+    /// [class]: https://doc.qt.io/qt-5/qqmlengine.html
+    pub unsafe struct QQmlEngine as "QQmlEngine"
+);
+
+impl QQmlEngine {
+    /// Sets a property for this QML context (calls QQmlEngine::rootContext()->setContextProperty)
+    pub fn set_property(&mut self, name: QString, value: QVariant) {
+        cpp!(unsafe [self as "QQmlEngine *", name as "QString", value as "QVariant"] {
+            self->rootContext()->setContextProperty(name, value);
+        })
+    }
+
+    /// Sets an object for this QML context (calls QQmlEngine::rootContext()->setContextObject)
+    pub fn set_object<T: QObject + Sized>(&mut self, obj: QObjectPinned<T>) {
+        let obj_ptr = obj.get_or_create_cpp_object();
+        cpp!(unsafe [self as "QQmlEngine *", obj_ptr as "QObject *"] {
+            self->rootContext()->setContextObject(obj_ptr);
+        })
+    }
+
+    /// Sets a property for this QML context (calls QQmlEngine::rootContext()->setContextProperty)
+    ///
+    // (TODO: consider making the lifetime the one of the engine, instead of static)
+    pub fn set_object_property<T: QObject + Sized>(
+        &mut self,
+        name: QString,
+        obj: QObjectPinned<T>,
+    ) {
+        let obj_ptr = obj.get_or_create_cpp_object();
+        cpp!(unsafe [self as "QQmlEngine *", name as "QString", obj_ptr as "QObject *"] {
+            self->rootContext()->setContextProperty(name, obj_ptr);
+        })
+    }
+
+    pub fn trim_component_cache(&self) {
+        cpp!(unsafe [self as "QQmlEngine *"] {
+            self->trimComponentCache();
+        })
+    }
+
+    pub fn clear_component_cache(&self) {
+        cpp!(unsafe [self as "QQmlEngine *"] {
+            self->clearComponentCache();
+        })
+    }
+
+    /// Adds an import path for this QML engine (calls QQmlEngine::addImportPath)
+    pub fn add_import_path(&mut self, path: QString) {
+        cpp!(unsafe [self as "QQmlEngine *", path as "QString"] {
+            self->addImportPath(path);
+        })
+    }
+
+    /// Returns a pointer to the C++ object. The pointer is of the type `QQmlEngine *` in C++.
+    pub fn cpp_ptr(&self) -> *mut c_void {
+        cpp!(unsafe [self as "QQmlEngine *"] -> *mut c_void as "QQmlEngine *" {
+            return self;
+        })
+    }
+}
+
 cpp! {{
     #include <memory>
     #include <QtQuick/QtQuick>
@@ -85,6 +149,19 @@ cpp_class!(
     /// QmlEngine at the same time is not allowed. Doing that will panic.
     pub unsafe struct QmlEngine as "QmlEngineHolder"
 );
+
+impl std::ops::Deref for QmlEngine {
+    type Target = QQmlEngine;
+
+    fn deref(&self) -> &Self::Target {
+        let ptr: *const QQmlEngine = cpp!(unsafe [self as "QmlEngineHolder *"] -> *const QQmlEngine as "QQmlEngine *" {
+            return self->engine.get();
+        });
+
+        unsafe { ptr.as_ref().expect("valid QQmlEngine") }
+    }
+}
+
 impl QmlEngine {
     /// Create a new QmlEngine
     pub fn new() -> QmlEngine {
@@ -166,35 +243,6 @@ impl QmlEngine {
         })
     }
 
-    /// Sets a property for this QML context (calls QQmlEngine::rootContext()->setContextProperty)
-    pub fn set_property(&mut self, name: QString, value: QVariant) {
-        cpp!(unsafe [self as "QmlEngineHolder *", name as "QString", value as "QVariant"] {
-            self->engine->rootContext()->setContextProperty(name, value);
-        })
-    }
-
-    /// Sets an object for this QML context (calls QQmlEngine::rootContext()->setContextObject)
-    pub fn set_object<T: QObject + Sized>(&mut self, obj: QObjectPinned<T>) {
-        let obj_ptr = obj.get_or_create_cpp_object();
-        cpp!(unsafe [self as "QmlEngineHolder *", obj_ptr as "QObject *"] {
-            self->engine->rootContext()->setContextObject(obj_ptr);
-        })
-    }
-
-    /// Sets a property for this QML context (calls QQmlEngine::rootContext()->setContextProperty)
-    ///
-    // (TODO: consider making the lifetime the one of the engine, instead of static)
-    pub fn set_object_property<T: QObject + Sized>(
-        &mut self,
-        name: QString,
-        obj: QObjectPinned<T>,
-    ) {
-        let obj_ptr = obj.get_or_create_cpp_object();
-        cpp!(unsafe [self as "QmlEngineHolder *", name as "QString", obj_ptr as "QObject *"] {
-            self->engine->rootContext()->setContextProperty(name, obj_ptr);
-        })
-    }
-
     pub fn invoke_method(&mut self, name: QByteArray, args: &[QVariant]) -> QVariant {
         let args_size = args.len();
         let args_ptr = args.as_ptr();
@@ -248,7 +296,7 @@ impl QmlEngine {
             if (robjs.isEmpty()) {
                 return;
             }
-            
+
             #define INVOKE_METHOD(...) QMetaObject::invokeMethod(robjs.first(), name __VA_ARGS__);
             switch (args_size) {
                 case 0: INVOKE_METHOD(); break;
@@ -266,18 +314,6 @@ impl QmlEngine {
         })
     }
 
-    pub fn trim_component_cache(&self) {
-        cpp!(unsafe [self as "QmlEngineHolder *"] {
-            self->engine->trimComponentCache();
-        })
-    }
-
-    pub fn clear_component_cache(&self) {
-        cpp!(unsafe [self as "QmlEngineHolder *"] {
-            self->engine->clearComponentCache();
-        })
-    }
-    
     /// Give a QObject to the engine by wrapping it in a QJSValue
     ///
     /// This will create the C++ object.
@@ -289,20 +325,6 @@ impl QmlEngine {
             obj_ptr as "QObject *"
         ] -> QJSValue as "QJSValue" {
             return self->engine->newQObject(obj_ptr);
-        })
-    }
-
-    /// Adds an import path for this QML engine (calls QQmlEngine::addImportPath)
-    pub fn add_import_path(&mut self, path: QString) {
-        cpp!(unsafe [self as "QmlEngineHolder *", path as "QString"] {
-            self->engine->addImportPath(path);
-        })
-    }
-
-    /// Returns a pointer to the C++ object. The pointer is of the type `QQmlEngine *` in C++.
-    pub fn cpp_ptr(&self) -> *mut c_void {
-        cpp!(unsafe [self as "QmlEngineHolder *"] -> *mut c_void as "QQmlEngine *" {
-            return self->engine.get();
         })
     }
 }


### PR DESCRIPTION
This introduces initialize_engine, such that plugins can register e.g. image providers (might file a PR for that too, but I've been using that with `cpp!` macros for now for a long time). These need access to the engine, and that can be done through this "callback".

This is 100% unsound, and doesn't compile (because Rust QmlEngine != C++ QQmlEngine etc), but filing to start the discussion. The problem is that QmlEngine, the Rust side, assumes ownership of the pointer. We could *leak* the pointer after using it, but if we then panic in the `initializeEngine` override, the pointer will get cleaned up. It's not ideal, and would love some suggestions.

GPT 5.4 suggests introducing a QmlEngineRef type, but that gets ugly quite fast because you need to duplicate all the methods (or break interface and call AsRef all the time), and it just doesn't *feel* right. Maybe we can track an "owned" flag in the struct, but that neither feels great. Any ideas, @ratijas / @ogoffart ?